### PR TITLE
refactor: Byte record bounds

### DIFF
--- a/core/src/operations/add.rs
+++ b/core/src/operations/add.rs
@@ -1,6 +1,5 @@
 use crate::air::{Word, WordAirBuilder};
 use crate::bytes::event::ByteRecord;
-use crate::runtime::ExecutionRecord;
 
 use p3_air::AirBuilder;
 use p3_field::{AbstractField, Field};
@@ -20,7 +19,7 @@ pub struct AddOperation<T> {
 impl<F: Field> AddOperation<F> {
     pub fn populate(
         &mut self,
-        record: &mut ExecutionRecord,
+        record: &mut impl ByteRecord,
         shard: u32,
         a_u32: u32,
         b_u32: u32,

--- a/core/src/operations/add4.rs
+++ b/core/src/operations/add4.rs
@@ -6,7 +6,6 @@ use crate::air::Word;
 use crate::air::WordAirBuilder;
 use crate::air::WORD_SIZE;
 use crate::bytes::event::ByteRecord;
-use crate::runtime::ExecutionRecord;
 
 /// A set of columns needed to compute the add of four words.
 #[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
@@ -34,7 +33,7 @@ pub struct Add4Operation<T> {
 impl<F: Field> Add4Operation<F> {
     pub fn populate(
         &mut self,
-        record: &mut ExecutionRecord,
+        record: &mut impl ByteRecord,
         shard: u32,
         a_u32: u32,
         b_u32: u32,

--- a/core/src/operations/add5.rs
+++ b/core/src/operations/add5.rs
@@ -6,7 +6,6 @@ use crate::air::Word;
 use crate::air::WordAirBuilder;
 use crate::air::WORD_SIZE;
 use crate::bytes::event::ByteRecord;
-use crate::runtime::ExecutionRecord;
 
 /// A set of columns needed to compute the sum of five words.
 #[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
@@ -38,7 +37,7 @@ impl<F: Field> Add5Operation<F> {
     #[allow(clippy::too_many_arguments)]
     pub fn populate(
         &mut self,
-        record: &mut ExecutionRecord,
+        record: &mut impl ByteRecord,
         shard: u32,
         a_u32: u32,
         b_u32: u32,

--- a/core/src/operations/and.rs
+++ b/core/src/operations/and.rs
@@ -7,7 +7,6 @@ use crate::bytes::event::ByteRecord;
 use crate::bytes::ByteLookupEvent;
 use crate::bytes::ByteOpcode;
 use crate::disassembler::WORD_SIZE;
-use crate::runtime::ExecutionRecord;
 
 /// A set of columns needed to compute the and of two words.
 #[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
@@ -18,7 +17,7 @@ pub struct AndOperation<T> {
 }
 
 impl<F: Field> AndOperation<F> {
-    pub fn populate(&mut self, record: &mut ExecutionRecord, shard: u32, x: u32, y: u32) -> u32 {
+    pub fn populate(&mut self, record: &mut impl ByteRecord, shard: u32, x: u32, y: u32) -> u32 {
         let expected = x & y;
         let x_bytes = x.to_le_bytes();
         let y_bytes = y.to_le_bytes();

--- a/core/src/operations/fixed_rotate_right.rs
+++ b/core/src/operations/fixed_rotate_right.rs
@@ -8,7 +8,6 @@ use crate::bytes::utils::shr_carry;
 use crate::bytes::ByteLookupEvent;
 use crate::bytes::ByteOpcode;
 use crate::disassembler::WORD_SIZE;
-use crate::runtime::ExecutionRecord;
 
 /// A set of columns needed to compute `rotateright` of a word with a fixed offset R.
 ///
@@ -42,7 +41,7 @@ impl<F: Field> FixedRotateRightOperation<F> {
 
     pub fn populate(
         &mut self,
-        record: &mut ExecutionRecord,
+        record: &mut impl ByteRecord,
         shard: u32,
         input: u32,
         rotation: usize,

--- a/core/src/operations/fixed_shift_right.rs
+++ b/core/src/operations/fixed_shift_right.rs
@@ -8,7 +8,6 @@ use crate::bytes::utils::shr_carry;
 use crate::bytes::ByteLookupEvent;
 use crate::bytes::ByteOpcode;
 use crate::disassembler::WORD_SIZE;
-use crate::runtime::ExecutionRecord;
 
 /// A set of columns needed to compute `>>` of a word with a fixed offset R.
 ///
@@ -42,7 +41,7 @@ impl<F: Field> FixedShiftRightOperation<F> {
 
     pub fn populate(
         &mut self,
-        record: &mut ExecutionRecord,
+        record: &mut impl ByteRecord,
         shard: u32,
         input: u32,
         rotation: usize,

--- a/core/src/operations/not.rs
+++ b/core/src/operations/not.rs
@@ -7,7 +7,6 @@ use crate::air::Word;
 use crate::bytes::event::ByteRecord;
 use crate::bytes::ByteOpcode;
 use crate::disassembler::WORD_SIZE;
-use crate::runtime::ExecutionRecord;
 
 /// A set of columns needed to compute the not of a word.
 #[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
@@ -18,7 +17,7 @@ pub struct NotOperation<T> {
 }
 
 impl<F: Field> NotOperation<F> {
-    pub fn populate(&mut self, record: &mut ExecutionRecord, shard: u32, x: u32) -> u32 {
+    pub fn populate(&mut self, record: &mut impl ByteRecord, shard: u32, x: u32) -> u32 {
         let expected = !x;
         let x_bytes = x.to_le_bytes();
         for i in 0..WORD_SIZE {

--- a/core/src/operations/or.rs
+++ b/core/src/operations/or.rs
@@ -6,7 +6,6 @@ use crate::air::Word;
 use crate::bytes::event::ByteRecord;
 use crate::bytes::ByteOpcode;
 use crate::disassembler::WORD_SIZE;
-use crate::runtime::ExecutionRecord;
 
 /// A set of columns needed to compute the or of two words.
 ///
@@ -19,7 +18,7 @@ pub struct OrOperation<T> {
 }
 
 impl<F: Field> OrOperation<F> {
-    pub fn populate(&mut self, record: &mut ExecutionRecord, shard: u32, x: u32, y: u32) -> u32 {
+    pub fn populate(&mut self, record: &mut impl ByteRecord, shard: u32, x: u32, y: u32) -> u32 {
         let expected = x | y;
         let x_bytes = x.to_le_bytes();
         let y_bytes = y.to_le_bytes();

--- a/core/src/operations/xor.rs
+++ b/core/src/operations/xor.rs
@@ -7,7 +7,6 @@ use crate::bytes::event::ByteRecord;
 use crate::bytes::ByteLookupEvent;
 use crate::bytes::ByteOpcode;
 use crate::disassembler::WORD_SIZE;
-use crate::runtime::ExecutionRecord;
 
 /// A set of columns needed to compute the xor of two words.
 #[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
@@ -18,7 +17,7 @@ pub struct XorOperation<T> {
 }
 
 impl<F: Field> XorOperation<F> {
-    pub fn populate(&mut self, record: &mut ExecutionRecord, shard: u32, x: u32, y: u32) -> u32 {
+    pub fn populate(&mut self, record: &mut impl ByteRecord, shard: u32, x: u32, y: u32) -> u32 {
         let expected = x ^ y;
         let x_bytes = x.to_le_bytes();
         let y_bytes = y.to_le_bytes();

--- a/core/src/syscall/precompiles/blake3/compress/g.rs
+++ b/core/src/syscall/precompiles/blake3/compress/g.rs
@@ -4,8 +4,8 @@ use sphinx_derive::AlignedBorrow;
 use super::g_func;
 use crate::{
     air::{Word, WordAirBuilder, WORD_SIZE},
+    bytes::event::ByteRecord,
     operations::{AddOperation, FixedRotateRightOperation, XorOperation},
-    runtime::ExecutionRecord,
 };
 /// A set of columns needed to compute the `g` of the input state.
 ///  ``` ignore
@@ -44,7 +44,7 @@ pub struct GOperation<T> {
 impl<F: Field> GOperation<F> {
     pub fn populate(
         &mut self,
-        record: &mut ExecutionRecord,
+        record: &mut impl ByteRecord,
         shard: u32,
         input: [u32; 6],
     ) -> [u32; 4] {

--- a/core/src/syscall/precompiles/edwards/ed_decompress.rs
+++ b/core/src/syscall/precompiles/edwards/ed_decompress.rs
@@ -97,7 +97,7 @@ impl<F: PrimeField32, P: FieldParameters> EdDecompressCols<F, P> {
     pub fn populate<E: EdwardsParameters<BaseField = P>>(
         &mut self,
         event: &EdDecompressEvent,
-        record: &mut ExecutionRecord,
+        record: &mut impl ByteRecord,
     ) {
         let mut new_byte_lookup_events = Vec::new();
         self.is_real = F::from_bool(true);


### PR DESCRIPTION
A simple initial fragment of decoupling the output from `ExecutionRecord`.