### PR TITLE
refactor: De-couple Chips from a specific ExecutionRecord, part II

### DIFF
--- a/core/src/air/machine.rs
+++ b/core/src/air/machine.rs
@@ -14,7 +14,7 @@ use crate::{
 pub trait WithEvents<'a>: Sized {
     /// output of a functional lens from the Record to
     /// refs of those events relative to the AIR.
-    type Events: 'a;
+    type InputEvents: 'a;
 }
 
 /// A trait intended for implementation on Records that may store events related to Chips,
@@ -23,7 +23,7 @@ pub trait WithEvents<'a>: Sized {
 ///
 /// The name is inspired by (but not conformant to) functional optics ( https://doi.org/10.1145/1232420.1232424 )
 pub trait EventLens<T: for<'b> WithEvents<'b>>: Indexed {
-    fn events(&self) -> <T as WithEvents<'_>>::Events;
+    fn events(&self) -> <T as WithEvents<'_>>::InputEvents;
 }
 
 //////////////// Derive macro shenanigans ////////////////////////////////////////////////
@@ -63,10 +63,10 @@ where
     R: EventLens<T>,
     U: for<'b> WithEvents<'b>,
     // see https://github.com/rust-lang/rust/issues/86702 for the empty parameter
-    F: for<'c> Fn(<T as WithEvents<'c>>::Events, &'c ()) -> <U as WithEvents<'c>>::Events,
+    F: for<'c> Fn(<T as WithEvents<'c>>::InputEvents, &'c ()) -> <U as WithEvents<'c>>::InputEvents,
 {
-    fn events<'c>(&'c self) -> <U as WithEvents<'c>>::Events {
-        let events: <T as WithEvents<'c>>::Events = self.record.events();
+    fn events<'c>(&'c self) -> <U as WithEvents<'c>>::InputEvents {
+        let events: <T as WithEvents<'c>>::InputEvents = self.record.events();
         (self.projection)(events, &())
     }
 }

--- a/core/src/alu/add_sub/mod.rs
+++ b/core/src/alu/add_sub/mod.rs
@@ -58,7 +58,7 @@ pub struct AddSubCols<T> {
 }
 
 impl<'a> WithEvents<'a> for AddSubChip {
-    type Events = (
+    type InputEvents = (
         // add events
         &'a [AluEvent],
         // sub events

--- a/core/src/alu/bitwise/mod.rs
+++ b/core/src/alu/bitwise/mod.rs
@@ -52,7 +52,7 @@ pub struct BitwiseCols<T> {
 }
 
 impl<'a> WithEvents<'a> for BitwiseChip {
-    type Events = &'a [AluEvent];
+    type InputEvents = &'a [AluEvent];
 }
 
 impl<F: PrimeField> MachineAir<F> for BitwiseChip {

--- a/core/src/alu/divrem/mod.rs
+++ b/core/src/alu/divrem/mod.rs
@@ -188,7 +188,7 @@ pub struct DivRemCols<T> {
 }
 
 impl<'a> WithEvents<'a> for DivRemChip {
-    type Events = &'a [AluEvent];
+    type InputEvents = &'a [AluEvent];
 }
 
 impl<F: PrimeField> MachineAir<F> for DivRemChip {

--- a/core/src/alu/lt/mod.rs
+++ b/core/src/alu/lt/mod.rs
@@ -94,7 +94,7 @@ impl LtCols<u32> {
 }
 
 impl<'a> WithEvents<'a> for LtChip {
-    type Events = &'a [AluEvent];
+    type InputEvents = &'a [AluEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for LtChip {

--- a/core/src/alu/mul/mod.rs
+++ b/core/src/alu/mul/mod.rs
@@ -124,7 +124,7 @@ pub struct MulCols<T> {
 }
 
 impl<'a> WithEvents<'a> for MulChip {
-    type Events = &'a [AluEvent];
+    type InputEvents = &'a [AluEvent];
 }
 
 impl<F: PrimeField> MachineAir<F> for MulChip {

--- a/core/src/alu/sll/mod.rs
+++ b/core/src/alu/sll/mod.rs
@@ -99,7 +99,7 @@ pub struct ShiftLeftCols<T> {
 }
 
 impl<'a> WithEvents<'a> for ShiftLeft {
-    type Events = &'a [AluEvent];
+    type InputEvents = &'a [AluEvent];
 }
 
 impl<F: PrimeField> MachineAir<F> for ShiftLeft {

--- a/core/src/alu/sr/mod.rs
+++ b/core/src/alu/sr/mod.rs
@@ -131,7 +131,7 @@ pub struct ShiftRightCols<T> {
 }
 
 impl<'a> WithEvents<'a> for ShiftRightChip {
-    type Events = &'a [AluEvent];
+    type InputEvents = &'a [AluEvent];
 }
 
 impl<F: PrimeField> MachineAir<F> for ShiftRightChip {

--- a/core/src/bytes/trace.rs
+++ b/core/src/bytes/trace.rs
@@ -16,7 +16,7 @@ pub const NUM_ROWS: usize = 1 << 16;
 
 impl<'a, F: Field> WithEvents<'a> for ByteChip<F> {
     // the byte lookups
-    type Events = &'a BTreeMap<u32, BTreeMap<ByteLookupEvent, usize>>;
+    type InputEvents = &'a BTreeMap<u32, BTreeMap<ByteLookupEvent, usize>>;
 }
 
 impl<F: Field> MachineAir<F> for ByteChip<F> {

--- a/core/src/bytes/trace.rs
+++ b/core/src/bytes/trace.rs
@@ -8,7 +8,7 @@ use super::{
     ByteChip, ByteLookupEvent,
 };
 use crate::{
-    air::{EventLens, MachineAir, WithEvents},
+    air::{EventLens, EventMutLens, MachineAir, WithEvents},
     runtime::{ExecutionRecord, Program},
 };
 
@@ -17,6 +17,7 @@ pub const NUM_ROWS: usize = 1 << 16;
 impl<'a, F: Field> WithEvents<'a> for ByteChip<F> {
     // the byte lookups
     type InputEvents = &'a BTreeMap<u32, BTreeMap<ByteLookupEvent, usize>>;
+    type OutputEvents = &'a ();
 }
 
 impl<F: Field> MachineAir<F> for ByteChip<F> {
@@ -40,18 +41,18 @@ impl<F: Field> MachineAir<F> for ByteChip<F> {
         Some(trace)
     }
 
-    fn generate_dependencies<EL: EventLens<Self>>(
+    fn generate_dependencies<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         _input: &EL,
-        _output: &mut ExecutionRecord,
+        _output: &mut OL,
     ) {
         // Do nothing since this chip has no dependencies.
     }
 
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        _output: &mut ExecutionRecord,
+        _output: &mut OL,
     ) -> RowMajorMatrix<F> {
         let shard = input.index();
         let (_, event_map) = Self::trace_and_map(shard);

--- a/core/src/cpu/trace.rs
+++ b/core/src/cpu/trace.rs
@@ -19,7 +19,7 @@ use crate::runtime::{ExecutionRecord, Opcode, Program};
 use crate::runtime::{MemoryRecordEnum, SyscallCode};
 
 impl<'a> WithEvents<'a> for CpuChip {
-    type Events = &'a [CpuEvent];
+    type InputEvents = &'a [CpuEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for CpuChip {

--- a/core/src/memory/global.rs
+++ b/core/src/memory/global.rs
@@ -43,7 +43,7 @@ impl<F> BaseAir<F> for MemoryChip {
 }
 
 impl<'a> WithEvents<'a> for MemoryChip {
-    type Events = (
+    type InputEvents = (
         // initialize events
         &'a [MemoryInitializeFinalizeEvent],
         // finalize events

--- a/core/src/memory/global.rs
+++ b/core/src/memory/global.rs
@@ -11,7 +11,8 @@ use sphinx_derive::AlignedBorrow;
 use super::MemoryInitializeFinalizeEvent;
 use crate::{
     air::{
-        AirInteraction, BaseAirBuilder, EventLens, MachineAir, WithEvents, Word, WordAirBuilder,
+        AirInteraction, BaseAirBuilder, EventLens, EventMutLens, MachineAir, WithEvents, Word,
+        WordAirBuilder,
     },
     runtime::{ExecutionRecord, Program},
     utils::pad_to_power_of_two,
@@ -49,6 +50,7 @@ impl<'a> WithEvents<'a> for MemoryChip {
         // finalize events
         &'a [MemoryInitializeFinalizeEvent],
     );
+    type OutputEvents = &'a ();
 }
 
 impl<F: PrimeField> MachineAir<F> for MemoryChip {
@@ -63,10 +65,10 @@ impl<F: PrimeField> MachineAir<F> for MemoryChip {
         }
     }
 
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        _output: &mut ExecutionRecord,
+        _output: &mut OL,
     ) -> RowMajorMatrix<F> {
         let mut memory_events: Vec<MemoryInitializeFinalizeEvent> = match self.kind {
             MemoryChipType::Initialize => input.events().0,
@@ -105,10 +107,10 @@ impl<F: PrimeField> MachineAir<F> for MemoryChip {
         trace
     }
 
-    fn generate_dependencies<EL: EventLens<Self>>(
+    fn generate_dependencies<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         _input: &EL,
-        _output: &mut ExecutionRecord,
+        _output: &mut OL,
     ) {
         // Do nothing since this chip has no dependencies.
     }

--- a/core/src/memory/program.rs
+++ b/core/src/memory/program.rs
@@ -51,7 +51,7 @@ impl MemoryProgramChip {
 }
 
 impl<'a> WithEvents<'a> for MemoryProgramChip {
-    type Events = &'a BTreeMap<u32, u32>;
+    type InputEvents = &'a BTreeMap<u32, u32>;
 }
 
 impl<F: PrimeField> MachineAir<F> for MemoryProgramChip {

--- a/core/src/memory/program.rs
+++ b/core/src/memory/program.rs
@@ -9,7 +9,9 @@ use std::collections::BTreeMap;
 
 use sphinx_derive::AlignedBorrow;
 
-use crate::air::{AirInteraction, BaseAirBuilder, EventLens, PublicValues, WithEvents};
+use crate::air::{
+    AirInteraction, BaseAirBuilder, EventLens, EventMutLens, PublicValues, WithEvents,
+};
 use crate::air::{MachineAir, Word};
 use crate::operations::IsZeroOperation;
 use crate::runtime::{ExecutionRecord, Program};
@@ -52,6 +54,7 @@ impl MemoryProgramChip {
 
 impl<'a> WithEvents<'a> for MemoryProgramChip {
     type InputEvents = &'a BTreeMap<u32, u32>;
+    type OutputEvents = &'a ();
 }
 
 impl<F: PrimeField> MachineAir<F> for MemoryProgramChip {
@@ -96,18 +99,18 @@ impl<F: PrimeField> MachineAir<F> for MemoryProgramChip {
         Some(trace)
     }
 
-    fn generate_dependencies<EL: EventLens<Self>>(
+    fn generate_dependencies<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         _input: &EL,
-        _output: &mut ExecutionRecord,
+        _output: &mut OL,
     ) {
         // Do nothing since this chip has no dependencies.
     }
 
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        _output: &mut ExecutionRecord,
+        _output: &mut OL,
     ) -> RowMajorMatrix<F> {
         let program_memory_addrs = input.events().keys().copied().collect::<Vec<_>>();
 

--- a/core/src/operations/field/extensions/quadratic/mod.rs
+++ b/core/src/operations/field/extensions/quadratic/mod.rs
@@ -380,7 +380,7 @@ mod tests {
 
     use super::{QuadFieldOpCols, QuadFieldOperation};
     use crate::air::MachineAir;
-    use crate::bytes::event::ByteRecord;
+
     use crate::bytes::ByteLookupEvent;
     use crate::operations::field::params::{FieldParameters, Limbs};
     use crate::runtime::{ExecutionRecord, Program};
@@ -420,17 +420,6 @@ mod tests {
     impl<P: FieldParameters> EventLens<QuadFieldOpChip<P>> for ExecutionRecord {
         fn events(&self) -> <QuadFieldOpChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
-        }
-    }
-
-    impl<P: FieldParameters> EventMutLens<QuadFieldOpChip<P>> for ExecutionRecord {
-        fn add_events(
-            &mut self,
-            events: <QuadFieldOpChip<P> as crate::air::WithEvents<'_>>::OutputEvents,
-        ) {
-            for event in events {
-                self.add_byte_lookup_event(*event);
-            }
         }
     }
 

--- a/core/src/operations/field/extensions/quadratic/mod.rs
+++ b/core/src/operations/field/extensions/quadratic/mod.rs
@@ -412,11 +412,11 @@ mod tests {
     }
 
     impl<'a, P: FieldParameters> crate::air::WithEvents<'a> for QuadFieldOpChip<P> {
-        type Events = &'a ();
+        type InputEvents = &'a ();
     }
 
     impl<P: FieldParameters> EventLens<QuadFieldOpChip<P>> for ExecutionRecord {
-        fn events(&self) -> <QuadFieldOpChip<P> as crate::air::WithEvents<'_>>::Events {
+        fn events(&self) -> <QuadFieldOpChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
         }
     }

--- a/core/src/operations/field/extensions/quadratic/sqrt.rs
+++ b/core/src/operations/field/extensions/quadratic/sqrt.rs
@@ -151,11 +151,11 @@ mod tests {
     }
 
     impl<'a, P: FieldParameters> crate::air::WithEvents<'a> for QuadSqrtChip<P> {
-        type Events = &'a ();
+        type InputEvents = &'a ();
     }
 
     impl<P: FieldParameters> EventLens<QuadSqrtChip<P>> for ExecutionRecord {
-        fn events(&self) -> <QuadSqrtChip<P> as crate::air::WithEvents<'_>>::Events {
+        fn events(&self) -> <QuadSqrtChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
         }
     }

--- a/core/src/operations/field/extensions/quadratic/sqrt.rs
+++ b/core/src/operations/field/extensions/quadratic/sqrt.rs
@@ -112,7 +112,7 @@ mod tests {
 
     use crate::air::MachineAir;
     use crate::air::{EventLens, EventMutLens, WordAirBuilder};
-    use crate::bytes::event::ByteRecord;
+
     use crate::bytes::ByteLookupEvent;
     use crate::operations::field::params::{FieldParameters, Limbs};
     use crate::runtime::ExecutionRecord;
@@ -159,17 +159,6 @@ mod tests {
     impl<P: FieldParameters> EventLens<QuadSqrtChip<P>> for ExecutionRecord {
         fn events(&self) -> <QuadSqrtChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
-        }
-    }
-
-    impl<P: FieldParameters> EventMutLens<QuadSqrtChip<P>> for ExecutionRecord {
-        fn add_events(
-            &mut self,
-            events: <QuadSqrtChip<P> as crate::air::WithEvents<'_>>::OutputEvents,
-        ) {
-            for event in events {
-                self.add_byte_lookup_event(*event);
-            }
         }
     }
 

--- a/core/src/operations/field/field_den.rs
+++ b/core/src/operations/field/field_den.rs
@@ -198,11 +198,11 @@ mod tests {
     }
 
     impl<'a, P: FieldParameters> crate::air::WithEvents<'a> for FieldDenChip<P> {
-        type Events = &'a ();
+        type InputEvents = &'a ();
     }
 
     impl<P: FieldParameters> EventLens<FieldDenChip<P>> for ExecutionRecord {
-        fn events(&self) -> <FieldDenChip<P> as crate::air::WithEvents<'_>>::Events {
+        fn events(&self) -> <FieldDenChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
         }
     }

--- a/core/src/operations/field/field_den.rs
+++ b/core/src/operations/field/field_den.rs
@@ -165,7 +165,6 @@ mod tests {
 
     use crate::{
         air::MachineAir,
-        bytes::event::ByteRecord,
         bytes::ByteLookupEvent,
         utils::ec::weierstrass::{bls12_381::Bls12381BaseField, secp256k1::Secp256k1BaseField},
     };
@@ -207,17 +206,6 @@ mod tests {
     impl<P: FieldParameters> EventLens<FieldDenChip<P>> for ExecutionRecord {
         fn events(&self) -> <FieldDenChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
-        }
-    }
-
-    impl<P: FieldParameters> EventMutLens<FieldDenChip<P>> for ExecutionRecord {
-        fn add_events(
-            &mut self,
-            events: <FieldDenChip<P> as crate::air::WithEvents<'_>>::OutputEvents,
-        ) {
-            for event in events {
-                self.add_byte_lookup_event(*event);
-            }
         }
     }
 

--- a/core/src/operations/field/field_inner_product.rs
+++ b/core/src/operations/field/field_inner_product.rs
@@ -186,11 +186,11 @@ mod tests {
     }
 
     impl<'a, P: FieldParameters> crate::air::WithEvents<'a> for FieldIpChip<P> {
-        type Events = &'a ();
+        type InputEvents = &'a ();
     }
 
     impl<P: FieldParameters> EventLens<FieldIpChip<P>> for ExecutionRecord {
-        fn events(&self) -> <FieldIpChip<P> as crate::air::WithEvents<'_>>::Events {
+        fn events(&self) -> <FieldIpChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
         }
     }

--- a/core/src/operations/field/field_inner_product.rs
+++ b/core/src/operations/field/field_inner_product.rs
@@ -155,7 +155,6 @@ mod tests {
     use crate::air::{EventLens, EventMutLens, WordAirBuilder};
     use crate::{
         air::MachineAir,
-        bytes::event::ByteRecord,
         bytes::ByteLookupEvent,
         utils::ec::weierstrass::{bls12_381::Bls12381BaseField, secp256k1::Secp256k1BaseField},
     };
@@ -196,17 +195,6 @@ mod tests {
     impl<P: FieldParameters> EventLens<FieldIpChip<P>> for ExecutionRecord {
         fn events(&self) -> <FieldIpChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
-        }
-    }
-
-    impl<P: FieldParameters> EventMutLens<FieldIpChip<P>> for ExecutionRecord {
-        fn add_events(
-            &mut self,
-            events: <FieldIpChip<P> as crate::air::WithEvents<'_>>::OutputEvents,
-        ) {
-            for event in events {
-                self.add_byte_lookup_event(*event);
-            }
         }
     }
 

--- a/core/src/operations/field/field_op.rs
+++ b/core/src/operations/field/field_op.rs
@@ -279,11 +279,11 @@ mod tests {
     }
 
     impl<'a, P: FieldParameters> crate::air::WithEvents<'a> for FieldOpChip<P> {
-        type Events = &'a ();
+        type InputEvents = &'a ();
     }
 
     impl<P: FieldParameters> EventLens<FieldOpChip<P>> for ExecutionRecord {
-        fn events(&self) -> <FieldOpChip<P> as crate::air::WithEvents<'_>>::Events {
+        fn events(&self) -> <FieldOpChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
         }
     }

--- a/core/src/operations/field/field_op.rs
+++ b/core/src/operations/field/field_op.rs
@@ -244,7 +244,7 @@ mod tests {
     use crate::{air::MachineAir, utils::ec::weierstrass::bls12_381::Bls12381BaseField};
 
     use crate::air::{EventLens, EventMutLens, WordAirBuilder};
-    use crate::bytes::event::ByteRecord;
+
     use crate::bytes::ByteLookupEvent;
     use crate::operations::field::params::FieldParameters;
     use crate::runtime::ExecutionRecord;
@@ -287,17 +287,6 @@ mod tests {
     impl<P: FieldParameters> EventLens<FieldOpChip<P>> for ExecutionRecord {
         fn events(&self) -> <FieldOpChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
-        }
-    }
-
-    impl<P: FieldParameters> EventMutLens<FieldOpChip<P>> for ExecutionRecord {
-        fn add_events(
-            &mut self,
-            events: <FieldOpChip<P> as crate::air::WithEvents<'_>>::OutputEvents,
-        ) {
-            for event in events {
-                self.add_byte_lookup_event(*event);
-            }
         }
     }
 

--- a/core/src/operations/field/field_sqrt.rs
+++ b/core/src/operations/field/field_sqrt.rs
@@ -152,11 +152,11 @@ mod tests {
     }
 
     impl<'a, P: FieldParameters> crate::air::WithEvents<'a> for EdSqrtChip<P> {
-        type Events = &'a ();
+        type InputEvents = &'a ();
     }
 
     impl<P: FieldParameters> EventLens<EdSqrtChip<P>> for ExecutionRecord {
-        fn events(&self) -> <EdSqrtChip<P> as crate::air::WithEvents<'_>>::Events {
+        fn events(&self) -> <EdSqrtChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
         }
     }

--- a/core/src/operations/field/field_sqrt.rs
+++ b/core/src/operations/field/field_sqrt.rs
@@ -121,7 +121,7 @@ mod tests {
 
     use crate::air::WordAirBuilder;
     use crate::air::{EventLens, EventMutLens, MachineAir};
-    use crate::bytes::event::ByteRecord;
+
     use crate::bytes::ByteLookupEvent;
     use crate::operations::field::params::{FieldParameters, DEFAULT_NUM_LIMBS_T};
     use crate::runtime::ExecutionRecord;
@@ -160,17 +160,6 @@ mod tests {
     impl<P: FieldParameters> EventLens<EdSqrtChip<P>> for ExecutionRecord {
         fn events(&self) -> <EdSqrtChip<P> as crate::air::WithEvents<'_>>::InputEvents {
             &()
-        }
-    }
-
-    impl<P: FieldParameters> EventMutLens<EdSqrtChip<P>> for ExecutionRecord {
-        fn add_events(
-            &mut self,
-            events: <EdSqrtChip<P> as crate::air::WithEvents<'_>>::OutputEvents,
-        ) {
-            for event in events {
-                self.add_byte_lookup_event(*event);
-            }
         }
     }
 

--- a/core/src/program/mod.rs
+++ b/core/src/program/mod.rs
@@ -53,7 +53,7 @@ impl ProgramChip {
 }
 
 impl<'a> WithEvents<'a> for ProgramChip {
-    type Events = (
+    type InputEvents = (
         // CPU events
         &'a [CpuEvent],
         // the Program

--- a/core/src/program/mod.rs
+++ b/core/src/program/mod.rs
@@ -10,7 +10,7 @@ use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use sphinx_derive::AlignedBorrow;
 
 use crate::{
-    air::{EventLens, MachineAir, ProgramAirBuilder, WithEvents},
+    air::{EventLens, EventMutLens, MachineAir, ProgramAirBuilder, WithEvents},
     cpu::{
         columns::{InstructionCols, OpcodeSelectorCols},
         CpuEvent,
@@ -59,6 +59,7 @@ impl<'a> WithEvents<'a> for ProgramChip {
         // the Program
         &'a Program,
     );
+    type OutputEvents = &'a ();
 }
 
 impl<F: PrimeField> MachineAir<F> for ProgramChip {
@@ -104,18 +105,18 @@ impl<F: PrimeField> MachineAir<F> for ProgramChip {
         Some(trace)
     }
 
-    fn generate_dependencies<EL: EventLens<Self>>(
+    fn generate_dependencies<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         _input: &EL,
-        _output: &mut ExecutionRecord,
+        _output: &mut OL,
     ) {
         // Do nothing since this chip has no dependencies.
     }
 
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        _output: &mut ExecutionRecord,
+        _output: &mut OL,
     ) -> RowMajorMatrix<F> {
         // Generate the trace rows for each event.
 

--- a/core/src/runtime/record.rs
+++ b/core/src/runtime/record.rs
@@ -146,139 +146,139 @@ pub struct ExecutionRecord {
 
 // Event lenses connect the record to the events relative to a particular chip
 impl EventLens<AddSubChip> for ExecutionRecord {
-    fn events(&self) -> <AddSubChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <AddSubChip as crate::air::WithEvents<'_>>::InputEvents {
         (&self.add_events, &self.sub_events)
     }
 }
 
 impl EventLens<BitwiseChip> for ExecutionRecord {
-    fn events(&self) -> <BitwiseChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <BitwiseChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.bitwise_events
     }
 }
 
 impl EventLens<DivRemChip> for ExecutionRecord {
-    fn events(&self) -> <DivRemChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <DivRemChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.divrem_events
     }
 }
 
 impl EventLens<LtChip> for ExecutionRecord {
-    fn events(&self) -> <LtChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <LtChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.lt_events
     }
 }
 
 impl EventLens<MulChip> for ExecutionRecord {
-    fn events(&self) -> <MulChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <MulChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.mul_events
     }
 }
 
 impl EventLens<ShiftLeft> for ExecutionRecord {
-    fn events(&self) -> <ShiftLeft as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <ShiftLeft as crate::air::WithEvents<'_>>::InputEvents {
         &self.shift_left_events
     }
 }
 
 impl EventLens<ShiftRightChip> for ExecutionRecord {
-    fn events(&self) -> <ShiftRightChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <ShiftRightChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.shift_right_events
     }
 }
 
 impl<F: Field> EventLens<ByteChip<F>> for ExecutionRecord {
-    fn events(&self) -> <ByteChip<F> as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <ByteChip<F> as crate::air::WithEvents<'_>>::InputEvents {
         &self.byte_lookups
     }
 }
 
 impl EventLens<CpuChip> for ExecutionRecord {
-    fn events(&self) -> <CpuChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <CpuChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.cpu_events
     }
 }
 
 impl EventLens<MemoryChip> for ExecutionRecord {
-    fn events(&self) -> <MemoryChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <MemoryChip as crate::air::WithEvents<'_>>::InputEvents {
         (&self.memory_initialize_events, &self.memory_finalize_events)
     }
 }
 
 impl EventLens<MemoryProgramChip> for ExecutionRecord {
-    fn events(&self) -> <MemoryProgramChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <MemoryProgramChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.program.memory_image
     }
 }
 
 impl EventLens<ProgramChip> for ExecutionRecord {
-    fn events(&self) -> <ProgramChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <ProgramChip as crate::air::WithEvents<'_>>::InputEvents {
         (&self.cpu_events, &self.program)
     }
 }
 
 impl EventLens<ShaExtendChip> for ExecutionRecord {
-    fn events(&self) -> <ShaExtendChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <ShaExtendChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.sha_extend_events
     }
 }
 
 impl EventLens<ShaCompressChip> for ExecutionRecord {
-    fn events(&self) -> <ShaCompressChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <ShaCompressChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.sha_compress_events
     }
 }
 
 impl EventLens<Blake3CompressInnerChip> for ExecutionRecord {
-    fn events(&self) -> <Blake3CompressInnerChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <Blake3CompressInnerChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.blake3_compress_inner_events
     }
 }
 
 impl EventLens<KeccakPermuteChip> for ExecutionRecord {
-    fn events(&self) -> <KeccakPermuteChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <KeccakPermuteChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.keccak_permute_events
     }
 }
 
 impl EventLens<Bls12381G1DecompressChip> for ExecutionRecord {
-    fn events(&self) -> <Bls12381G1DecompressChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <Bls12381G1DecompressChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_g1_decompress_events
     }
 }
 
 impl EventLens<Secp256k1DecompressChip> for ExecutionRecord {
-    fn events(&self) -> <Secp256k1DecompressChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <Secp256k1DecompressChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.secp256k1_decompress_events
     }
 }
 
 impl EventLens<Bls12381G2AffineAddChip> for ExecutionRecord {
-    fn events(&self) -> <Bls12381G2AffineAddChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <Bls12381G2AffineAddChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_g2_add_events
     }
 }
 
 impl EventLens<Bls12381G2AffineDoubleChip> for ExecutionRecord {
-    fn events(&self) -> <Bls12381G2AffineDoubleChip as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <Bls12381G2AffineDoubleChip as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_g2_double_events
     }
 }
 
 impl EventLens<FieldAddChip<Bls12381BaseField>> for ExecutionRecord {
-    fn events(&self) -> <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_fp_add_events
     }
 }
 
 impl EventLens<FieldSubChip<Bls12381BaseField>> for ExecutionRecord {
-    fn events(&self) -> <FieldSubChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <FieldSubChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_fp_sub_events
     }
 }
 
 impl EventLens<FieldMulChip<Bls12381BaseField>> for ExecutionRecord {
-    fn events(&self) -> <FieldMulChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <FieldMulChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_fp_mul_events
     }
 }
@@ -286,7 +286,7 @@ impl EventLens<FieldMulChip<Bls12381BaseField>> for ExecutionRecord {
 impl EventLens<QuadFieldAddChip<Bls12381BaseField>> for ExecutionRecord {
     fn events(
         &self,
-    ) -> <QuadFieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::Events {
+    ) -> <QuadFieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_fp2_add_events
     }
 }
@@ -294,7 +294,7 @@ impl EventLens<QuadFieldAddChip<Bls12381BaseField>> for ExecutionRecord {
 impl EventLens<QuadFieldSubChip<Bls12381BaseField>> for ExecutionRecord {
     fn events(
         &self,
-    ) -> <QuadFieldSubChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::Events {
+    ) -> <QuadFieldSubChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_fp2_sub_events
     }
 }
@@ -302,7 +302,7 @@ impl EventLens<QuadFieldSubChip<Bls12381BaseField>> for ExecutionRecord {
 impl EventLens<QuadFieldMulChip<Bls12381BaseField>> for ExecutionRecord {
     fn events(
         &self,
-    ) -> <QuadFieldMulChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::Events {
+    ) -> <QuadFieldMulChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_fp2_mul_events
     }
 }
@@ -310,19 +310,19 @@ impl EventLens<QuadFieldMulChip<Bls12381BaseField>> for ExecutionRecord {
 impl EventLens<WeierstrassAddAssignChip<Secp256k1>> for ExecutionRecord {
     fn events(
         &self,
-    ) -> <WeierstrassAddAssignChip<Secp256k1> as crate::air::WithEvents<'_>>::Events {
+    ) -> <WeierstrassAddAssignChip<Secp256k1> as crate::air::WithEvents<'_>>::InputEvents {
         &self.secp256k1_add_events
     }
 }
 
 impl EventLens<WeierstrassAddAssignChip<Bls12381>> for ExecutionRecord {
-    fn events(&self) -> <WeierstrassAddAssignChip<Bls12381> as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <WeierstrassAddAssignChip<Bls12381> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_g1_add_events
     }
 }
 
 impl EventLens<WeierstrassAddAssignChip<Bn254>> for ExecutionRecord {
-    fn events(&self) -> <WeierstrassAddAssignChip<Bn254> as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <WeierstrassAddAssignChip<Bn254> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bn254_add_events
     }
 }
@@ -330,7 +330,7 @@ impl EventLens<WeierstrassAddAssignChip<Bn254>> for ExecutionRecord {
 impl EventLens<WeierstrassDoubleAssignChip<Secp256k1>> for ExecutionRecord {
     fn events(
         &self,
-    ) -> <WeierstrassDoubleAssignChip<Secp256k1> as crate::air::WithEvents<'_>>::Events {
+    ) -> <WeierstrassDoubleAssignChip<Secp256k1> as crate::air::WithEvents<'_>>::InputEvents {
         &self.secp256k1_double_events
     }
 }
@@ -338,19 +338,19 @@ impl EventLens<WeierstrassDoubleAssignChip<Secp256k1>> for ExecutionRecord {
 impl EventLens<WeierstrassDoubleAssignChip<Bls12381>> for ExecutionRecord {
     fn events(
         &self,
-    ) -> <WeierstrassDoubleAssignChip<Bls12381> as crate::air::WithEvents<'_>>::Events {
+    ) -> <WeierstrassDoubleAssignChip<Bls12381> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bls12381_g1_double_events
     }
 }
 
 impl EventLens<WeierstrassDoubleAssignChip<Bn254>> for ExecutionRecord {
-    fn events(&self) -> <WeierstrassDoubleAssignChip<Bn254> as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <WeierstrassDoubleAssignChip<Bn254> as crate::air::WithEvents<'_>>::InputEvents {
         &self.bn254_double_events
     }
 }
 
 impl EventLens<EdAddAssignChip<Ed25519>> for ExecutionRecord {
-    fn events(&self) -> <EdAddAssignChip<Ed25519> as crate::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <EdAddAssignChip<Ed25519> as crate::air::WithEvents<'_>>::InputEvents {
         &self.ed_add_events
     }
 }
@@ -358,7 +358,7 @@ impl EventLens<EdAddAssignChip<Ed25519>> for ExecutionRecord {
 impl EventLens<EdDecompressChip<Ed25519Parameters>> for ExecutionRecord {
     fn events(
         &self,
-    ) -> <EdDecompressChip<Ed25519Parameters> as crate::air::WithEvents<'_>>::Events {
+    ) -> <EdDecompressChip<Ed25519Parameters> as crate::air::WithEvents<'_>>::InputEvents {
         &self.ed_decompress_events
     }
 }

--- a/core/src/runtime/record.rs
+++ b/core/src/runtime/record.rs
@@ -9,7 +9,6 @@ use p3_field::{AbstractField, Field};
 use serde::{Deserialize, Serialize};
 
 use super::{program::Program, Opcode};
-use crate::cpu::CpuEvent;
 use crate::runtime::MemoryInitializeFinalizeEvent;
 use crate::runtime::MemoryRecordEnum;
 use crate::stark::MachineRecord;
@@ -32,6 +31,7 @@ use crate::{
     },
     utils::ec::weierstrass::bls12_381::Bls12381BaseField,
 };
+use crate::{air::WithEvents, cpu::CpuEvent};
 use crate::{
     air::{EventLens, EventMutLens},
     alu::AluEvent,
@@ -146,253 +146,211 @@ pub struct ExecutionRecord {
 
 // Event lenses connect the record to the events relative to a particular chip
 impl EventLens<AddSubChip> for ExecutionRecord {
-    fn events(&self) -> <AddSubChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <AddSubChip as WithEvents<'_>>::InputEvents {
         (&self.add_events, &self.sub_events)
     }
 }
 
 impl EventLens<BitwiseChip> for ExecutionRecord {
-    fn events(&self) -> <BitwiseChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <BitwiseChip as WithEvents<'_>>::InputEvents {
         &self.bitwise_events
     }
 }
 
 impl EventLens<DivRemChip> for ExecutionRecord {
-    fn events(&self) -> <DivRemChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <DivRemChip as WithEvents<'_>>::InputEvents {
         &self.divrem_events
     }
 }
 
 impl EventLens<LtChip> for ExecutionRecord {
-    fn events(&self) -> <LtChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <LtChip as WithEvents<'_>>::InputEvents {
         &self.lt_events
     }
 }
 
 impl EventLens<MulChip> for ExecutionRecord {
-    fn events(&self) -> <MulChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <MulChip as WithEvents<'_>>::InputEvents {
         &self.mul_events
     }
 }
 
 impl EventLens<ShiftLeft> for ExecutionRecord {
-    fn events(&self) -> <ShiftLeft as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <ShiftLeft as WithEvents<'_>>::InputEvents {
         &self.shift_left_events
     }
 }
 
 impl EventLens<ShiftRightChip> for ExecutionRecord {
-    fn events(&self) -> <ShiftRightChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <ShiftRightChip as WithEvents<'_>>::InputEvents {
         &self.shift_right_events
     }
 }
 
 impl<F: Field> EventLens<ByteChip<F>> for ExecutionRecord {
-    fn events(&self) -> <ByteChip<F> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <ByteChip<F> as WithEvents<'_>>::InputEvents {
         &self.byte_lookups
     }
 }
 
 impl EventLens<CpuChip> for ExecutionRecord {
-    fn events(&self) -> <CpuChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <CpuChip as WithEvents<'_>>::InputEvents {
         &self.cpu_events
     }
 }
 
 impl EventLens<MemoryChip> for ExecutionRecord {
-    fn events(&self) -> <MemoryChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <MemoryChip as WithEvents<'_>>::InputEvents {
         (&self.memory_initialize_events, &self.memory_finalize_events)
     }
 }
 
 impl EventLens<MemoryProgramChip> for ExecutionRecord {
-    fn events(&self) -> <MemoryProgramChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <MemoryProgramChip as WithEvents<'_>>::InputEvents {
         &self.program.memory_image
     }
 }
 
 impl EventLens<ProgramChip> for ExecutionRecord {
-    fn events(&self) -> <ProgramChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <ProgramChip as WithEvents<'_>>::InputEvents {
         (&self.cpu_events, &self.program)
     }
 }
 
 impl EventLens<ShaExtendChip> for ExecutionRecord {
-    fn events(&self) -> <ShaExtendChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <ShaExtendChip as WithEvents<'_>>::InputEvents {
         &self.sha_extend_events
     }
 }
 
 impl EventLens<ShaCompressChip> for ExecutionRecord {
-    fn events(&self) -> <ShaCompressChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <ShaCompressChip as WithEvents<'_>>::InputEvents {
         &self.sha_compress_events
     }
 }
 
 impl EventLens<Blake3CompressInnerChip> for ExecutionRecord {
-    fn events(&self) -> <Blake3CompressInnerChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <Blake3CompressInnerChip as WithEvents<'_>>::InputEvents {
         &self.blake3_compress_inner_events
     }
 }
 
 impl EventLens<KeccakPermuteChip> for ExecutionRecord {
-    fn events(&self) -> <KeccakPermuteChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <KeccakPermuteChip as WithEvents<'_>>::InputEvents {
         &self.keccak_permute_events
     }
 }
 
 impl EventLens<Bls12381G1DecompressChip> for ExecutionRecord {
-    fn events(&self) -> <Bls12381G1DecompressChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <Bls12381G1DecompressChip as WithEvents<'_>>::InputEvents {
         &self.bls12381_g1_decompress_events
     }
 }
 
 impl EventLens<Secp256k1DecompressChip> for ExecutionRecord {
-    fn events(&self) -> <Secp256k1DecompressChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <Secp256k1DecompressChip as WithEvents<'_>>::InputEvents {
         &self.secp256k1_decompress_events
     }
 }
 
 impl EventLens<Bls12381G2AffineAddChip> for ExecutionRecord {
-    fn events(&self) -> <Bls12381G2AffineAddChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <Bls12381G2AffineAddChip as WithEvents<'_>>::InputEvents {
         &self.bls12381_g2_add_events
     }
 }
 
 impl EventLens<Bls12381G2AffineDoubleChip> for ExecutionRecord {
-    fn events(&self) -> <Bls12381G2AffineDoubleChip as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <Bls12381G2AffineDoubleChip as WithEvents<'_>>::InputEvents {
         &self.bls12381_g2_double_events
     }
 }
 
 impl EventLens<FieldAddChip<Bls12381BaseField>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <FieldAddChip<Bls12381BaseField> as WithEvents<'_>>::InputEvents {
         &self.bls12381_fp_add_events
     }
 }
 
 impl EventLens<FieldSubChip<Bls12381BaseField>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <FieldSubChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <FieldSubChip<Bls12381BaseField> as WithEvents<'_>>::InputEvents {
         &self.bls12381_fp_sub_events
     }
 }
 
 impl EventLens<FieldMulChip<Bls12381BaseField>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <FieldMulChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <FieldMulChip<Bls12381BaseField> as WithEvents<'_>>::InputEvents {
         &self.bls12381_fp_mul_events
     }
 }
 
 impl EventLens<QuadFieldAddChip<Bls12381BaseField>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <QuadFieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <QuadFieldAddChip<Bls12381BaseField> as WithEvents<'_>>::InputEvents {
         &self.bls12381_fp2_add_events
     }
 }
 
 impl EventLens<QuadFieldSubChip<Bls12381BaseField>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <QuadFieldSubChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <QuadFieldSubChip<Bls12381BaseField> as WithEvents<'_>>::InputEvents {
         &self.bls12381_fp2_sub_events
     }
 }
 
 impl EventLens<QuadFieldMulChip<Bls12381BaseField>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <QuadFieldMulChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <QuadFieldMulChip<Bls12381BaseField> as WithEvents<'_>>::InputEvents {
         &self.bls12381_fp2_mul_events
     }
 }
 
 impl EventLens<WeierstrassAddAssignChip<Secp256k1>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <WeierstrassAddAssignChip<Secp256k1> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <WeierstrassAddAssignChip<Secp256k1> as WithEvents<'_>>::InputEvents {
         &self.secp256k1_add_events
     }
 }
 
 impl EventLens<WeierstrassAddAssignChip<Bls12381>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <WeierstrassAddAssignChip<Bls12381> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <WeierstrassAddAssignChip<Bls12381> as WithEvents<'_>>::InputEvents {
         &self.bls12381_g1_add_events
     }
 }
 
 impl EventLens<WeierstrassAddAssignChip<Bn254>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <WeierstrassAddAssignChip<Bn254> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <WeierstrassAddAssignChip<Bn254> as WithEvents<'_>>::InputEvents {
         &self.bn254_add_events
     }
 }
 
 impl EventLens<WeierstrassDoubleAssignChip<Secp256k1>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <WeierstrassDoubleAssignChip<Secp256k1> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <WeierstrassDoubleAssignChip<Secp256k1> as WithEvents<'_>>::InputEvents {
         &self.secp256k1_double_events
     }
 }
 
 impl EventLens<WeierstrassDoubleAssignChip<Bls12381>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <WeierstrassDoubleAssignChip<Bls12381> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <WeierstrassDoubleAssignChip<Bls12381> as WithEvents<'_>>::InputEvents {
         &self.bls12381_g1_double_events
     }
 }
 
 impl EventLens<WeierstrassDoubleAssignChip<Bn254>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <WeierstrassDoubleAssignChip<Bn254> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <WeierstrassDoubleAssignChip<Bn254> as WithEvents<'_>>::InputEvents {
         &self.bn254_double_events
     }
 }
 
 impl EventLens<EdAddAssignChip<Ed25519>> for ExecutionRecord {
-    fn events(&self) -> <EdAddAssignChip<Ed25519> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <EdAddAssignChip<Ed25519> as WithEvents<'_>>::InputEvents {
         &self.ed_add_events
     }
 }
 
 impl EventLens<EdDecompressChip<Ed25519Parameters>> for ExecutionRecord {
-    fn events(
-        &self,
-    ) -> <EdDecompressChip<Ed25519Parameters> as crate::air::WithEvents<'_>>::InputEvents {
+    fn events(&self) -> <EdDecompressChip<Ed25519Parameters> as WithEvents<'_>>::InputEvents {
         &self.ed_decompress_events
     }
 }
 
-impl EventMutLens<AddSubChip> for ExecutionRecord {
-    fn add_events(&mut self, events: <AddSubChip as crate::air::WithEvents<'_>>::OutputEvents) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<BitwiseChip> for ExecutionRecord {
-    fn add_events(&mut self, events: <BitwiseChip as crate::air::WithEvents<'_>>::OutputEvents) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
 impl EventMutLens<DivRemChip> for ExecutionRecord {
-    fn add_events(&mut self, events: <DivRemChip as crate::air::WithEvents<'_>>::OutputEvents) {
+    fn add_events(&mut self, events: <DivRemChip as WithEvents<'_>>::OutputEvents) {
         for event in events {
             match event {
                 DivRemEvent::ByteLookupEvent(e) => self.add_byte_lookup_event(**e),
@@ -403,44 +361,12 @@ impl EventMutLens<DivRemChip> for ExecutionRecord {
     }
 }
 
-impl EventMutLens<LtChip> for ExecutionRecord {
-    fn add_events(&mut self, events: <LtChip as crate::air::WithEvents<'_>>::OutputEvents) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<MulChip> for ExecutionRecord {
-    fn add_events(&mut self, events: <MulChip as crate::air::WithEvents<'_>>::OutputEvents) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<ShiftLeft> for ExecutionRecord {
-    fn add_events(&mut self, events: <ShiftLeft as crate::air::WithEvents<'_>>::OutputEvents) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<ShiftRightChip> for ExecutionRecord {
-    fn add_events(&mut self, events: <ShiftRightChip as crate::air::WithEvents<'_>>::OutputEvents) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
 impl<F: Field> EventMutLens<ByteChip<F>> for ExecutionRecord {
-    fn add_events(&mut self, _events: <ByteChip<F> as crate::air::WithEvents<'_>>::OutputEvents) {}
+    fn add_events(&mut self, _events: <ByteChip<F> as WithEvents<'_>>::OutputEvents) {}
 }
 
 impl EventMutLens<CpuChip> for ExecutionRecord {
-    fn add_events(&mut self, events: <CpuChip as crate::air::WithEvents<'_>>::OutputEvents) {
+    fn add_events(&mut self, events: <CpuChip as WithEvents<'_>>::OutputEvents) {
         for event in events {
             match event {
                 CpuOutputEvent::ByteLookupEvent(e) => self.add_byte_lookup_event(**e),
@@ -466,254 +392,22 @@ impl EventMutLens<CpuChip> for ExecutionRecord {
 }
 
 impl EventMutLens<MemoryChip> for ExecutionRecord {
-    fn add_events(&mut self, _events: <MemoryChip as crate::air::WithEvents<'_>>::OutputEvents) {}
+    fn add_events(&mut self, _events: <MemoryChip as WithEvents<'_>>::OutputEvents) {}
 }
 
 impl EventMutLens<MemoryProgramChip> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        _events: <MemoryProgramChip as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-    }
+    fn add_events(&mut self, _events: <MemoryProgramChip as WithEvents<'_>>::OutputEvents) {}
 }
 
 impl EventMutLens<ProgramChip> for ExecutionRecord {
-    fn add_events(&mut self, _events: <ProgramChip as crate::air::WithEvents<'_>>::OutputEvents) {}
+    fn add_events(&mut self, _events: <ProgramChip as WithEvents<'_>>::OutputEvents) {}
 }
 
-impl EventMutLens<ShaExtendChip> for ExecutionRecord {
-    fn add_events(&mut self, events: <ShaExtendChip as crate::air::WithEvents<'_>>::OutputEvents) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<ShaCompressChip> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <ShaCompressChip as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<Blake3CompressInnerChip> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <Blake3CompressInnerChip as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<KeccakPermuteChip> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <KeccakPermuteChip as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<Bls12381G1DecompressChip> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <Bls12381G1DecompressChip as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<Secp256k1DecompressChip> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <Secp256k1DecompressChip as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<Bls12381G2AffineAddChip> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <Bls12381G2AffineAddChip as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<Bls12381G2AffineDoubleChip> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <Bls12381G2AffineDoubleChip as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<FieldAddChip<Bls12381BaseField>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<FieldSubChip<Bls12381BaseField>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<FieldMulChip<Bls12381BaseField>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<QuadFieldAddChip<Bls12381BaseField>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<QuadFieldSubChip<Bls12381BaseField>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<QuadFieldMulChip<Bls12381BaseField>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<WeierstrassAddAssignChip<Secp256k1>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<WeierstrassAddAssignChip<Bls12381>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<WeierstrassAddAssignChip<Bn254>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<WeierstrassDoubleAssignChip<Secp256k1>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<WeierstrassDoubleAssignChip<Bls12381>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<WeierstrassDoubleAssignChip<Bn254>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<EdAddAssignChip<Ed25519>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <EdAddAssignChip<Ed25519> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
-        for event in events {
-            self.add_byte_lookup_event(*event);
-        }
-    }
-}
-
-impl EventMutLens<EdDecompressChip<Ed25519Parameters>> for ExecutionRecord {
-    fn add_events(
-        &mut self,
-        events: <FieldAddChip<Bls12381BaseField> as crate::air::WithEvents<'_>>::OutputEvents,
-    ) {
+// For a straightforward addition to the byte record table, we can systematize:
+impl<Chip: for<'a> WithEvents<'a, OutputEvents = &'a [ByteLookupEvent]>> EventMutLens<Chip>
+    for ExecutionRecord
+{
+    fn add_events(&mut self, events: <Chip as WithEvents<'_>>::OutputEvents) {
         for event in events {
             self.add_byte_lookup_event(*event);
         }

--- a/core/src/syscall/precompiles/blake3/compress/trace.rs
+++ b/core/src/syscall/precompiles/blake3/compress/trace.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 impl<'a> WithEvents<'a> for Blake3CompressInnerChip {
-    type Events = &'a [Blake3CompressInnerEvent];
+    type InputEvents = &'a [Blake3CompressInnerEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for Blake3CompressInnerChip {

--- a/core/src/syscall/precompiles/bls12_381/g1_decompress.rs
+++ b/core/src/syscall/precompiles/bls12_381/g1_decompress.rs
@@ -230,7 +230,7 @@ impl Bls12381G1DecompressChip {
 }
 
 impl<'a> WithEvents<'a> for Bls12381G1DecompressChip {
-    type Events = &'a [Bls12381G1DecompressEvent];
+    type InputEvents = &'a [Bls12381G1DecompressEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for Bls12381G1DecompressChip {

--- a/core/src/syscall/precompiles/bls12_381/g2_add.rs
+++ b/core/src/syscall/precompiles/bls12_381/g2_add.rs
@@ -277,7 +277,7 @@ impl<T: PrimeField32> BaseAir<T> for Bls12381G2AffineAddChip {
 }
 
 impl<'a> WithEvents<'a> for Bls12381G2AffineAddChip {
-    type Events = &'a [Bls12381G2AffineAddEvent];
+    type InputEvents = &'a [Bls12381G2AffineAddEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for Bls12381G2AffineAddChip {

--- a/core/src/syscall/precompiles/bls12_381/g2_double.rs
+++ b/core/src/syscall/precompiles/bls12_381/g2_double.rs
@@ -1,5 +1,6 @@
-use crate::air::{EventLens, MachineAir, WithEvents};
+use crate::air::{EventLens, EventMutLens, MachineAir, WithEvents};
 use crate::bytes::event::ByteRecord;
+use crate::bytes::ByteLookupEvent;
 use crate::memory::{MemoryCols, MemoryWriteCols};
 use crate::operations::field::extensions::quadratic::{QuadFieldOpCols, QuadFieldOperation};
 use crate::operations::field::params::{FieldParameters, Limbs, WORDS_QUAD_EXT_CURVEPOINT};
@@ -227,6 +228,7 @@ impl<T: PrimeField32> BaseAir<T> for Bls12381G2AffineDoubleChip {
 
 impl<'a> WithEvents<'a> for Bls12381G2AffineDoubleChip {
     type InputEvents = &'a [Bls12381G2AffineDoubleEvent];
+    type OutputEvents = &'a [ByteLookupEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for Bls12381G2AffineDoubleChip {
@@ -237,10 +239,10 @@ impl<F: PrimeField32> MachineAir<F> for Bls12381G2AffineDoubleChip {
         "Bls12381G2AffineDoubleChip".to_string()
     }
 
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        output: &mut Self::Record,
+        output: &mut OL,
     ) -> RowMajorMatrix<F> {
         let mut rows: Vec<Vec<F>> = vec![];
 
@@ -280,7 +282,7 @@ impl<F: PrimeField32> MachineAir<F> for Bls12381G2AffineDoubleChip {
             rows.push(row);
         }
 
-        output.add_byte_lookup_events(new_byte_lookup_events);
+        output.add_events(&new_byte_lookup_events);
 
         pad_vec_rows(&mut rows, || {
             let mut row = vec![F::zero(); width];

--- a/core/src/syscall/precompiles/bls12_381/g2_double.rs
+++ b/core/src/syscall/precompiles/bls12_381/g2_double.rs
@@ -226,7 +226,7 @@ impl<T: PrimeField32> BaseAir<T> for Bls12381G2AffineDoubleChip {
 }
 
 impl<'a> WithEvents<'a> for Bls12381G2AffineDoubleChip {
-    type Events = &'a [Bls12381G2AffineDoubleEvent];
+    type InputEvents = &'a [Bls12381G2AffineDoubleEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for Bls12381G2AffineDoubleChip {

--- a/core/src/syscall/precompiles/edwards/ed_add.rs
+++ b/core/src/syscall/precompiles/edwards/ed_add.rs
@@ -144,7 +144,7 @@ impl<
 }
 
 impl<'a, E: EllipticCurve + EdwardsParameters> WithEvents<'a> for EdAddAssignChip<E> {
-    type Events = &'a [ECAddEvent];
+    type InputEvents = &'a [ECAddEvent];
 }
 
 impl<F: PrimeField32, E: EllipticCurve + EdwardsParameters> MachineAir<F> for EdAddAssignChip<E>

--- a/core/src/syscall/precompiles/edwards/ed_decompress.rs
+++ b/core/src/syscall/precompiles/edwards/ed_decompress.rs
@@ -334,7 +334,7 @@ impl<E: EdwardsParameters> EdDecompressChip<E> {
 }
 
 impl<'a, E: EdwardsParameters> WithEvents<'a> for EdDecompressChip<E> {
-    type Events = &'a [EdDecompressEvent];
+    type InputEvents = &'a [EdDecompressEvent];
 }
 
 impl<F: PrimeField32, E: EdwardsParameters> MachineAir<F> for EdDecompressChip<E>

--- a/core/src/syscall/precompiles/field/add.rs
+++ b/core/src/syscall/precompiles/field/add.rs
@@ -15,8 +15,8 @@ use sphinx_derive::AlignedBorrow;
 use tracing::instrument;
 
 use crate::{
-    air::{AluAirBuilder, EventLens, MachineAir, MemoryAirBuilder, WithEvents},
-    bytes::{event::ByteRecord, ByteLookupEvent},
+    air::{AluAirBuilder, EventLens, EventMutLens, MachineAir, MemoryAirBuilder, WithEvents},
+    bytes::ByteLookupEvent,
     memory::{MemoryCols, MemoryReadCols, MemoryWriteCols},
     operations::field::{
         field_op::{FieldOpCols, FieldOperation},
@@ -115,11 +115,12 @@ pub fn create_fp_add_event<FP: FieldParameters>(
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for FieldAddChip<FP> {
     type InputEvents = &'a [FieldAddEvent<FP>];
+    type OutputEvents = &'a [ByteLookupEvent];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for FieldAddChip<FP>
 where
-    ExecutionRecord: EventLens<FieldAddChip<FP>>,
+    ExecutionRecord: EventLens<FieldAddChip<FP>> + EventMutLens<FieldAddChip<FP>>,
 {
     type Record = ExecutionRecord;
     type Program = Program;
@@ -132,10 +133,10 @@ where
     }
 
     #[instrument(name = "generate field add trace", level = "debug", skip_all)]
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        output: &mut ExecutionRecord,
+        output: &mut OL,
     ) -> RowMajorMatrix<F> {
         // collects the events based on the field type.
         let events = input.events();
@@ -184,7 +185,7 @@ where
             .unzip();
 
         for byte_lookup_events in new_byte_lookup_events {
-            output.add_byte_lookup_events(byte_lookup_events);
+            output.add_events(&byte_lookup_events);
         }
 
         pad_vec_rows(&mut rows, || {

--- a/core/src/syscall/precompiles/field/add.rs
+++ b/core/src/syscall/precompiles/field/add.rs
@@ -114,7 +114,7 @@ pub fn create_fp_add_event<FP: FieldParameters>(
 }
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for FieldAddChip<FP> {
-    type Events = &'a [FieldAddEvent<FP>];
+    type InputEvents = &'a [FieldAddEvent<FP>];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for FieldAddChip<FP>

--- a/core/src/syscall/precompiles/field/mul.rs
+++ b/core/src/syscall/precompiles/field/mul.rs
@@ -114,7 +114,7 @@ pub fn create_fp_mul_event<FP: FieldParameters>(
 }
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for FieldMulChip<FP> {
-    type Events = &'a [FieldMulEvent<FP>];
+    type InputEvents = &'a [FieldMulEvent<FP>];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for FieldMulChip<FP>

--- a/core/src/syscall/precompiles/field/mul.rs
+++ b/core/src/syscall/precompiles/field/mul.rs
@@ -15,8 +15,8 @@ use sphinx_derive::AlignedBorrow;
 use tracing::instrument;
 
 use crate::{
-    air::{AluAirBuilder, EventLens, MachineAir, MemoryAirBuilder, WithEvents},
-    bytes::{event::ByteRecord, ByteLookupEvent},
+    air::{AluAirBuilder, EventLens, EventMutLens, MachineAir, MemoryAirBuilder, WithEvents},
+    bytes::ByteLookupEvent,
     memory::{MemoryCols, MemoryReadCols, MemoryWriteCols},
     operations::field::{
         field_op::{FieldOpCols, FieldOperation},
@@ -115,11 +115,12 @@ pub fn create_fp_mul_event<FP: FieldParameters>(
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for FieldMulChip<FP> {
     type InputEvents = &'a [FieldMulEvent<FP>];
+    type OutputEvents = &'a [ByteLookupEvent];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for FieldMulChip<FP>
 where
-    ExecutionRecord: EventLens<FieldMulChip<FP>>,
+    ExecutionRecord: EventLens<FieldMulChip<FP>> + EventMutLens<FieldMulChip<FP>>,
 {
     type Record = ExecutionRecord;
     type Program = Program;
@@ -132,10 +133,10 @@ where
     }
 
     #[instrument(name = "generate field mul trace", level = "debug", skip_all)]
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        output: &mut ExecutionRecord,
+        output: &mut OL,
     ) -> RowMajorMatrix<F> {
         // collects the events based on the field type.
         let events = input.events();
@@ -183,7 +184,7 @@ where
             .unzip();
 
         for byte_lookup_events in new_byte_lookup_events {
-            output.add_byte_lookup_events(byte_lookup_events);
+            output.add_events(&byte_lookup_events);
         }
 
         pad_vec_rows(&mut rows, || {

--- a/core/src/syscall/precompiles/field/sub.rs
+++ b/core/src/syscall/precompiles/field/sub.rs
@@ -15,8 +15,8 @@ use sphinx_derive::AlignedBorrow;
 use tracing::instrument;
 
 use crate::{
-    air::{AluAirBuilder, EventLens, MachineAir, MemoryAirBuilder, WithEvents},
-    bytes::{event::ByteRecord, ByteLookupEvent},
+    air::{AluAirBuilder, EventLens, EventMutLens, MachineAir, MemoryAirBuilder, WithEvents},
+    bytes::ByteLookupEvent,
     memory::{MemoryCols, MemoryReadCols, MemoryWriteCols},
     operations::field::{
         field_op::{FieldOpCols, FieldOperation},
@@ -115,11 +115,12 @@ pub fn create_fp_sub_event<FP: FieldParameters>(
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for FieldSubChip<FP> {
     type InputEvents = &'a [FieldSubEvent<FP>];
+    type OutputEvents = &'a [ByteLookupEvent];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for FieldSubChip<FP>
 where
-    ExecutionRecord: EventLens<FieldSubChip<FP>>,
+    ExecutionRecord: EventLens<FieldSubChip<FP>> + EventMutLens<FieldSubChip<FP>>,
 {
     type Record = ExecutionRecord;
     type Program = Program;
@@ -132,10 +133,10 @@ where
     }
 
     #[instrument(name = "generate field sub trace", level = "debug", skip_all)]
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        output: &mut ExecutionRecord,
+        output: &mut OL,
     ) -> RowMajorMatrix<F> {
         // collects the events based on the field type.
         let events = input.events();
@@ -183,7 +184,7 @@ where
             .unzip();
 
         for byte_lookup_events in new_byte_lookup_events {
-            output.add_byte_lookup_events(byte_lookup_events);
+            output.add_events(&byte_lookup_events);
         }
 
         pad_vec_rows(&mut rows, || {

--- a/core/src/syscall/precompiles/field/sub.rs
+++ b/core/src/syscall/precompiles/field/sub.rs
@@ -114,7 +114,7 @@ pub fn create_fp_sub_event<FP: FieldParameters>(
 }
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for FieldSubChip<FP> {
-    type Events = &'a [FieldSubEvent<FP>];
+    type InputEvents = &'a [FieldSubEvent<FP>];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for FieldSubChip<FP>

--- a/core/src/syscall/precompiles/keccak256/trace.rs
+++ b/core/src/syscall/precompiles/keccak256/trace.rs
@@ -18,7 +18,7 @@ use super::{
 };
 
 impl<'a> WithEvents<'a> for KeccakPermuteChip {
-    type Events = &'a [KeccakPermuteEvent];
+    type InputEvents = &'a [KeccakPermuteEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for KeccakPermuteChip {

--- a/core/src/syscall/precompiles/quad_field/add.rs
+++ b/core/src/syscall/precompiles/quad_field/add.rs
@@ -15,8 +15,8 @@ use sphinx_derive::AlignedBorrow;
 use tracing::instrument;
 
 use crate::{
-    air::{AluAirBuilder, EventLens, MachineAir, MemoryAirBuilder, WithEvents},
-    bytes::{event::ByteRecord, ByteLookupEvent},
+    air::{AluAirBuilder, EventLens, EventMutLens, MachineAir, MemoryAirBuilder, WithEvents},
+    bytes::ByteLookupEvent,
     memory::{MemoryCols, MemoryReadCols, MemoryWriteCols},
     operations::field::{
         extensions::quadratic::{QuadFieldOpCols, QuadFieldOperation},
@@ -141,11 +141,12 @@ pub fn create_fp2_add_event<FP: FieldParameters>(
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for QuadFieldAddChip<FP> {
     type InputEvents = &'a [QuadFieldAddEvent<FP>];
+    type OutputEvents = &'a [ByteLookupEvent];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for QuadFieldAddChip<FP>
 where
-    ExecutionRecord: EventLens<QuadFieldAddChip<FP>>,
+    ExecutionRecord: EventLens<QuadFieldAddChip<FP>> + EventMutLens<QuadFieldAddChip<FP>>,
 {
     type Record = ExecutionRecord;
     type Program = Program;
@@ -158,10 +159,10 @@ where
     }
 
     #[instrument(name = "generate bls12381 fp2 add trace", level = "debug", skip_all)]
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        output: &mut ExecutionRecord,
+        output: &mut OL,
     ) -> RowMajorMatrix<F> {
         // collects the events based on the field type.
         let events = input.events();
@@ -215,7 +216,7 @@ where
             .unzip();
 
         for byte_lookup_events in new_byte_lookup_events {
-            output.add_byte_lookup_events(byte_lookup_events);
+            output.add_events(&byte_lookup_events);
         }
 
         pad_vec_rows(&mut rows, || {

--- a/core/src/syscall/precompiles/quad_field/add.rs
+++ b/core/src/syscall/precompiles/quad_field/add.rs
@@ -140,7 +140,7 @@ pub fn create_fp2_add_event<FP: FieldParameters>(
 }
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for QuadFieldAddChip<FP> {
-    type Events = &'a [QuadFieldAddEvent<FP>];
+    type InputEvents = &'a [QuadFieldAddEvent<FP>];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for QuadFieldAddChip<FP>

--- a/core/src/syscall/precompiles/quad_field/mul.rs
+++ b/core/src/syscall/precompiles/quad_field/mul.rs
@@ -15,8 +15,8 @@ use sphinx_derive::AlignedBorrow;
 use tracing::instrument;
 
 use crate::{
-    air::{AluAirBuilder, EventLens, MachineAir, MemoryAirBuilder, WithEvents},
-    bytes::{event::ByteRecord, ByteLookupEvent},
+    air::{AluAirBuilder, EventLens, EventMutLens, MachineAir, MemoryAirBuilder, WithEvents},
+    bytes::ByteLookupEvent,
     memory::{MemoryCols, MemoryReadCols, MemoryWriteCols},
     operations::field::{
         extensions::quadratic::{QuadFieldOpCols, QuadFieldOperation},
@@ -150,11 +150,12 @@ pub fn create_fp2_mul_event<FP: FieldParameters>(
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for QuadFieldMulChip<FP> {
     type InputEvents = &'a [QuadFieldMulEvent<FP>];
+    type OutputEvents = &'a [ByteLookupEvent];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for QuadFieldMulChip<FP>
 where
-    ExecutionRecord: EventLens<QuadFieldMulChip<FP>>,
+    ExecutionRecord: EventLens<QuadFieldMulChip<FP>> + EventMutLens<QuadFieldMulChip<FP>>,
 {
     type Record = ExecutionRecord;
     type Program = Program;
@@ -167,10 +168,10 @@ where
     }
 
     #[instrument(name = "generate bls12381 fp2 mul trace", level = "debug", skip_all)]
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OL: EventMutLens<Self>>(
         &self,
         input: &EL,
-        output: &mut ExecutionRecord,
+        output: &mut OL,
     ) -> RowMajorMatrix<F> {
         // collects the events based on the field type.
         let events = input.events();
@@ -224,7 +225,7 @@ where
             .unzip();
 
         for byte_lookup_events in new_byte_lookup_events {
-            output.add_byte_lookup_events(byte_lookup_events);
+            output.add_events(&byte_lookup_events);
         }
 
         pad_vec_rows(&mut rows, || {

--- a/core/src/syscall/precompiles/quad_field/mul.rs
+++ b/core/src/syscall/precompiles/quad_field/mul.rs
@@ -149,7 +149,7 @@ pub fn create_fp2_mul_event<FP: FieldParameters>(
 }
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for QuadFieldMulChip<FP> {
-    type Events = &'a [QuadFieldMulEvent<FP>];
+    type InputEvents = &'a [QuadFieldMulEvent<FP>];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for QuadFieldMulChip<FP>

--- a/core/src/syscall/precompiles/quad_field/sub.rs
+++ b/core/src/syscall/precompiles/quad_field/sub.rs
@@ -140,7 +140,7 @@ pub fn create_fp2_sub_event<FP: FieldParameters>(
 }
 
 impl<'a, FP: FieldParameters> WithEvents<'a> for QuadFieldSubChip<FP> {
-    type Events = &'a [QuadFieldSubEvent<FP>];
+    type InputEvents = &'a [QuadFieldSubEvent<FP>];
 }
 
 impl<F: PrimeField32, FP: FieldParameters> MachineAir<F> for QuadFieldSubChip<FP>

--- a/core/src/syscall/precompiles/secp256k1/decompress.rs
+++ b/core/src/syscall/precompiles/secp256k1/decompress.rs
@@ -215,7 +215,7 @@ impl Secp256k1DecompressChip {
 }
 
 impl<'a> WithEvents<'a> for Secp256k1DecompressChip {
-    type Events = &'a [Secp256k1DecompressEvent];
+    type InputEvents = &'a [Secp256k1DecompressEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for Secp256k1DecompressChip {

--- a/core/src/syscall/precompiles/sha256/compress/trace.rs
+++ b/core/src/syscall/precompiles/sha256/compress/trace.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 impl<'a> WithEvents<'a> for ShaCompressChip {
-    type Events = &'a [ShaCompressEvent];
+    type InputEvents = &'a [ShaCompressEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for ShaCompressChip {

--- a/core/src/syscall/precompiles/sha256/extend/trace.rs
+++ b/core/src/syscall/precompiles/sha256/extend/trace.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 impl<'a> WithEvents<'a> for ShaExtendChip {
-    type Events = &'a [ShaExtendEvent];
+    type InputEvents = &'a [ShaExtendEvent];
 }
 
 impl<F: PrimeField32> MachineAir<F> for ShaExtendChip {

--- a/core/src/syscall/precompiles/weierstrass/weierstrass_add.rs
+++ b/core/src/syscall/precompiles/weierstrass/weierstrass_add.rs
@@ -150,7 +150,7 @@ impl<E: EllipticCurve> WeierstrassAddAssignChip<E> {
 }
 
 impl<'a, E: EllipticCurve + WeierstrassParameters> WithEvents<'a> for WeierstrassAddAssignChip<E> {
-    type Events = &'a [ECAddEvent<<E::BaseField as FieldParameters>::NB_LIMBS>];
+    type InputEvents = &'a [ECAddEvent<<E::BaseField as FieldParameters>::NB_LIMBS>];
 }
 
 impl<F: PrimeField32, E: EllipticCurve + WeierstrassParameters> MachineAir<F>

--- a/core/src/syscall/precompiles/weierstrass/weierstrass_double.rs
+++ b/core/src/syscall/precompiles/weierstrass/weierstrass_double.rs
@@ -176,7 +176,7 @@ impl<E: EllipticCurve + WeierstrassParameters> WeierstrassDoubleAssignChip<E> {
 impl<'a, E: EllipticCurve + WeierstrassParameters> WithEvents<'a>
     for WeierstrassDoubleAssignChip<E>
 {
-    type Events = &'a [ECDoubleEvent<<E::BaseField as FieldParameters>::NB_LIMBS>];
+    type InputEvents = &'a [ECDoubleEvent<<E::BaseField as FieldParameters>::NB_LIMBS>];
 }
 
 impl<F: PrimeField32, E: EllipticCurve + WeierstrassParameters> MachineAir<F>

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -123,12 +123,12 @@ pub fn with_events_air_derive(input: TokenStream) -> TokenStream {
             let field_ty_events = fields.iter().map(|field| {
                 let field_ty = &field.ty;
                 quote! {
-                    <#field_ty as #sphinx_core_path::air::WithEvents<'a>>::Events
+                    <#field_ty as #sphinx_core_path::air::WithEvents<'a>>::InputEvents
                 }
             });
             quote!{
                 impl <'a, #(#type_params),*, #(#const_params),*> #sphinx_core_path::air::WithEvents<'a> for #name #ty_generics #where_clause {
-                    type Events = (#(#field_ty_events,)*);
+                    type InputEvents = (#(#field_ty_events,)*);
                 }
             }.into()
         }
@@ -210,7 +210,7 @@ pub fn event_lens_air_derive(input: TokenStream) -> TokenStream {
             });
             let res = quote! {
                 impl #impl_generics #sphinx_core_path::air::EventLens<#name #ty_generics> for #rec_ty {
-                    fn events(&self) -> <#name #ty_generics as #sphinx_core_path::air::WithEvents>::Events {
+                    fn events(&self) -> <#name #ty_generics as #sphinx_core_path::air::WithEvents>::InputEvents {
                         (#(#field_events,)*)
                     }
                 }
@@ -308,7 +308,7 @@ pub fn machine_air_derive(input: TokenStream) -> TokenStream {
                 let idx = syn::Index::from(i);
                 quote! {
                     #name::#variant_name(x) => {
-                        fn f <'c, #ty_params, #co_params> (evs: <#name #ty_generics as #sphinx_core_path::air::WithEvents<'c>>::Events, _v: &'c ()) -> <#field_ty as #sphinx_core_path::air::WithEvents<'c>>::Events  { evs.#idx }
+                        fn f <'c, #ty_params, #co_params> (evs: <#name #ty_generics as #sphinx_core_path::air::WithEvents<'c>>::InputEvents, _v: &'c ()) -> <#field_ty as #sphinx_core_path::air::WithEvents<'c>>::InputEvents  { evs.#idx }
 
                         <#field_ty as #sphinx_core_path::air::MachineAir<F>>::generate_trace(x, &#sphinx_core_path::air::Proj::new(input, f #turbo_ty), output)
                     }
@@ -321,7 +321,7 @@ pub fn machine_air_derive(input: TokenStream) -> TokenStream {
 
                 quote! {
                     #name::#variant_name(x) => {
-                        fn f <'c, #ty_params, #co_params> (evs: <#name #ty_generics as #sphinx_core_path::air::WithEvents<'c>>::Events, _v: &'c ()) -> <#field_ty as #sphinx_core_path::air::WithEvents<'c>>::Events  { evs.#idx }
+                        fn f <'c, #ty_params, #co_params> (evs: <#name #ty_generics as #sphinx_core_path::air::WithEvents<'c>>::InputEvents, _v: &'c ()) -> <#field_ty as #sphinx_core_path::air::WithEvents<'c>>::InputEvents  { evs.#idx }
 
                         <#field_ty as #sphinx_core_path::air::MachineAir<F>>::generate_dependencies(x, &#sphinx_core_path::air::Proj::new(input, f #turbo_ty), output)
                     }

--- a/recursion/core/src/cpu/trace.rs
+++ b/recursion/core/src/cpu/trace.rs
@@ -17,7 +17,7 @@ use crate::{
 use super::{CpuChip, CpuCols, CpuEvent, CPU_COL_MAP, NUM_CPU_COLS};
 
 impl<'a, F: Field> WithEvents<'a> for CpuChip<F> {
-    type Events = &'a [CpuEvent<F>];
+    type InputEvents = &'a [CpuEvent<F>];
 }
 
 impl<F: PrimeField32 + BinomiallyExtendable<D>> MachineAir<F> for CpuChip<F>

--- a/recursion/core/src/fri_fold/mod.rs
+++ b/recursion/core/src/fri_fold/mod.rs
@@ -11,7 +11,8 @@ use p3_field::{AbstractField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use sphinx_core::air::{
-    BaseAirBuilder, BinomialExtension, EventLens, ExtensionAirBuilder, MachineAir, WithEvents,
+    BaseAirBuilder, BinomialExtension, EventLens, EventMutLens, ExtensionAirBuilder, MachineAir,
+    WithEvents,
 };
 use sphinx_core::utils::pad_rows_fixed;
 use sphinx_derive::AlignedBorrow;
@@ -95,6 +96,7 @@ impl<F: Field, const DEGREE: usize> BaseAir<F> for FriFoldChip<F, DEGREE> {
 
 impl<'a, F: Field, const DEGREE: usize> WithEvents<'a> for FriFoldChip<F, DEGREE> {
     type InputEvents = &'a [FriFoldEvent<F>];
+    type OutputEvents = &'a ();
 }
 
 impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for FriFoldChip<F, DEGREE> {
@@ -106,15 +108,19 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for FriFoldChip<F, DEGR
         "FriFold".to_string()
     }
 
-    fn generate_dependencies<EL: EventLens<Self>>(&self, _: &EL, _: &mut Self::Record) {
+    fn generate_dependencies<EL: EventLens<Self>, OR: EventMutLens<Self>>(
+        &self,
+        _: &EL,
+        _: &mut OR,
+    ) {
         // This is a no-op.
     }
 
     #[instrument(name = "generate fri fold trace", level = "debug", skip_all, fields(rows = input.events().len()))]
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OR: EventMutLens<Self>>(
         &self,
         input: &EL,
-        _: &mut ExecutionRecord<F>,
+        _: &mut OR,
     ) -> RowMajorMatrix<F> {
         let mut rows = input
             .events()

--- a/recursion/core/src/fri_fold/mod.rs
+++ b/recursion/core/src/fri_fold/mod.rs
@@ -94,7 +94,7 @@ impl<F: Field, const DEGREE: usize> BaseAir<F> for FriFoldChip<F, DEGREE> {
 }
 
 impl<'a, F: Field, const DEGREE: usize> WithEvents<'a> for FriFoldChip<F, DEGREE> {
-    type Events = &'a [FriFoldEvent<F>];
+    type InputEvents = &'a [FriFoldEvent<F>];
 }
 
 impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for FriFoldChip<F, DEGREE> {

--- a/recursion/core/src/memory/air.rs
+++ b/recursion/core/src/memory/air.rs
@@ -31,7 +31,7 @@ impl<F> MemoryGlobalChip<F> {
 }
 
 impl<'a, F: Field> WithEvents<'a> for MemoryGlobalChip<F> {
-    type Events = (
+    type InputEvents = (
         // first memory event
         &'a [(F, Block<F>)],
         // last memory event

--- a/recursion/core/src/multi/mod.rs
+++ b/recursion/core/src/multi/mod.rs
@@ -51,9 +51,9 @@ impl<F: Field, const DEGREE: usize> BaseAir<F> for MultiChip<F, DEGREE> {
 }
 
 impl<'a, F: Field, const DEGREE: usize> WithEvents<'a> for MultiChip<F, DEGREE> {
-    type Events = (
-        <FriFoldChip<F, DEGREE> as WithEvents<'a>>::Events,
-        <Poseidon2Chip<F> as WithEvents<'a>>::Events,
+    type InputEvents = (
+        <FriFoldChip<F, DEGREE> as WithEvents<'a>>::InputEvents,
+        <Poseidon2Chip<F> as WithEvents<'a>>::InputEvents,
     );
 }
 
@@ -79,16 +79,16 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for MultiChip<F, DEGREE
         let poseidon2 = Poseidon2Chip::default();
 
         fn to_fri<'c, F: PrimeField32, const DEGREE: usize>(
-            evs: <MultiChip<F, DEGREE> as WithEvents<'c>>::Events,
+            evs: <MultiChip<F, DEGREE> as WithEvents<'c>>::InputEvents,
             _v: &'c (),
-        ) -> <FriFoldChip<F, DEGREE> as WithEvents<'c>>::Events {
+        ) -> <FriFoldChip<F, DEGREE> as WithEvents<'c>>::InputEvents {
             evs.0
         }
 
         fn to_poseidon<'c, F: PrimeField32, const DEGREE: usize>(
-            evs: <MultiChip<F, DEGREE> as WithEvents<'c>>::Events,
+            evs: <MultiChip<F, DEGREE> as WithEvents<'c>>::InputEvents,
             _v: &'c (),
-        ) -> <Poseidon2Chip<F> as WithEvents<'c>>::Events {
+        ) -> <Poseidon2Chip<F> as WithEvents<'c>>::InputEvents {
             evs.1
         }
 

--- a/recursion/core/src/poseidon2/trace.rs
+++ b/recursion/core/src/poseidon2/trace.rs
@@ -20,7 +20,7 @@ use super::{
 };
 
 impl<'a, F: Field> WithEvents<'a> for Poseidon2Chip<F> {
-    type Events = &'a [Poseidon2Event<F>];
+    type InputEvents = &'a [Poseidon2Event<F>];
 }
 
 impl<F: PrimeField32> MachineAir<F> for Poseidon2Chip<F> {

--- a/recursion/core/src/poseidon2/trace.rs
+++ b/recursion/core/src/poseidon2/trace.rs
@@ -3,7 +3,7 @@ use std::borrow::BorrowMut;
 use p3_field::{Field, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 use sphinx_core::{
-    air::{EventLens, MachineAir, WithEvents},
+    air::{EventLens, EventMutLens, MachineAir, WithEvents},
     utils::pad_rows_fixed,
 };
 use sphinx_primitives::RC_16_30_U32;
@@ -21,6 +21,7 @@ use super::{
 
 impl<'a, F: Field> WithEvents<'a> for Poseidon2Chip<F> {
     type InputEvents = &'a [Poseidon2Event<F>];
+    type OutputEvents = &'a ();
 }
 
 impl<F: PrimeField32> MachineAir<F> for Poseidon2Chip<F> {
@@ -32,15 +33,19 @@ impl<F: PrimeField32> MachineAir<F> for Poseidon2Chip<F> {
         "Poseidon2".to_string()
     }
 
-    fn generate_dependencies<EL: EventLens<Self>>(&self, _: &EL, _: &mut Self::Record) {
+    fn generate_dependencies<EL: EventLens<Self>, OR: EventMutLens<Self>>(
+        &self,
+        _: &EL,
+        _: &mut OR,
+    ) {
         // This is a no-op.
     }
 
     #[instrument(name = "generate poseidon2 trace", level = "debug", skip_all, fields(rows = input.events().len()))]
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OR: EventMutLens<Self>>(
         &self,
         input: &EL,
-        _: &mut ExecutionRecord<F>,
+        _: &mut OR,
     ) -> RowMajorMatrix<F> {
         let mut rows = Vec::new();
 

--- a/recursion/core/src/poseidon2_wide/external.rs
+++ b/recursion/core/src/poseidon2_wide/external.rs
@@ -39,7 +39,7 @@ pub struct Poseidon2WideChip<F: Field, const DEGREE: usize> {
 }
 
 impl<'a, F: Field, const DEGREE: usize> WithEvents<'a> for Poseidon2WideChip<F, DEGREE> {
-    type Events = &'a [Poseidon2Event<F>];
+    type InputEvents = &'a [Poseidon2Event<F>];
 }
 
 impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for Poseidon2WideChip<F, DEGREE> {

--- a/recursion/core/src/poseidon2_wide/external.rs
+++ b/recursion/core/src/poseidon2_wide/external.rs
@@ -9,7 +9,7 @@ use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, Field, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
-use sphinx_core::air::{BaseAirBuilder, EventLens, MachineAir, WithEvents};
+use sphinx_core::air::{BaseAirBuilder, EventLens, EventMutLens, MachineAir, WithEvents};
 use sphinx_core::utils::pad_rows_fixed;
 use sphinx_primitives::RC_16_30_U32;
 use std::borrow::BorrowMut;
@@ -40,6 +40,7 @@ pub struct Poseidon2WideChip<F: Field, const DEGREE: usize> {
 
 impl<'a, F: Field, const DEGREE: usize> WithEvents<'a> for Poseidon2WideChip<F, DEGREE> {
     type InputEvents = &'a [Poseidon2Event<F>];
+    type OutputEvents = &'a ();
 }
 
 impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for Poseidon2WideChip<F, DEGREE> {
@@ -51,15 +52,19 @@ impl<F: PrimeField32, const DEGREE: usize> MachineAir<F> for Poseidon2WideChip<F
         format!("Poseidon2Wide {}", DEGREE)
     }
 
-    fn generate_dependencies<EL: EventLens<Self>>(&self, _: &EL, _: &mut Self::Record) {
+    fn generate_dependencies<EL: EventLens<Self>, OR: EventMutLens<Self>>(
+        &self,
+        _: &EL,
+        _: &mut OR,
+    ) {
         // This is a no-op.
     }
 
     #[instrument(name = "generate poseidon2 wide trace", level = "debug", skip_all, fields(rows = input.events().len()))]
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OR: EventMutLens<Self>>(
         &self,
         input: &EL,
-        _: &mut ExecutionRecord<F>,
+        _: &mut OR,
     ) -> RowMajorMatrix<F> {
         let mut rows = Vec::new();
 

--- a/recursion/core/src/program/mod.rs
+++ b/recursion/core/src/program/mod.rs
@@ -49,7 +49,7 @@ impl<F> ProgramChip<F> {
 }
 
 impl<'a, F: Field> WithEvents<'a> for ProgramChip<F> {
-    type Events = (
+    type InputEvents = (
         // program.instructions
         &'a [Instruction<F>],
         // cpu_events

--- a/recursion/core/src/range_check/trace.rs
+++ b/recursion/core/src/range_check/trace.rs
@@ -13,7 +13,7 @@ use crate::runtime::{ExecutionRecord, RecursionProgram};
 pub const NUM_ROWS: usize = 1 << 16;
 
 impl<'a, F: Field> WithEvents<'a> for RangeCheckChip<F> {
-    type Events = &'a BTreeMap<RangeCheckEvent, usize>;
+    type InputEvents = &'a BTreeMap<RangeCheckEvent, usize>;
 }
 
 impl<F: PrimeField32> MachineAir<F> for RangeCheckChip<F> {

--- a/recursion/core/src/range_check/trace.rs
+++ b/recursion/core/src/range_check/trace.rs
@@ -2,7 +2,7 @@ use std::{borrow::BorrowMut, collections::BTreeMap};
 
 use p3_field::{Field, PrimeField32};
 use p3_matrix::dense::RowMajorMatrix;
-use sphinx_core::air::{EventLens, MachineAir, WithEvents};
+use sphinx_core::air::{EventLens, EventMutLens, MachineAir, WithEvents};
 
 use super::{
     columns::{RangeCheckMultCols, NUM_RANGE_CHECK_MULT_COLS, NUM_RANGE_CHECK_PREPROCESSED_COLS},
@@ -14,6 +14,7 @@ pub const NUM_ROWS: usize = 1 << 16;
 
 impl<'a, F: Field> WithEvents<'a> for RangeCheckChip<F> {
     type InputEvents = &'a BTreeMap<RangeCheckEvent, usize>;
+    type OutputEvents = &'a ();
 }
 
 impl<F: PrimeField32> MachineAir<F> for RangeCheckChip<F> {
@@ -34,14 +35,18 @@ impl<F: PrimeField32> MachineAir<F> for RangeCheckChip<F> {
         Some(trace)
     }
 
-    fn generate_dependencies<EL: EventLens<Self>>(&self, _: &EL, _: &mut Self::Record) {
+    fn generate_dependencies<EL: EventLens<Self>, OR: EventMutLens<Self>>(
+        &self,
+        _: &EL,
+        _: &mut OR,
+    ) {
         // This is a no-op.
     }
 
-    fn generate_trace<EL: EventLens<Self>>(
+    fn generate_trace<EL: EventLens<Self>, OR: EventMutLens<Self>>(
         &self,
         input: &EL,
-        _output: &mut ExecutionRecord<F>,
+        _output: &mut OR,
     ) -> RowMajorMatrix<F> {
         let (_, event_map) = Self::trace_and_map();
 

--- a/recursion/core/src/runtime/record.rs
+++ b/recursion/core/src/runtime/record.rs
@@ -101,7 +101,7 @@ impl<F: PrimeField32> MachineRecord for ExecutionRecord<F> {
 }
 
 impl<F: PrimeField32> EventLens<CpuChip<F>> for ExecutionRecord<F> {
-    fn events(&self) -> <CpuChip<F> as sphinx_core::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <CpuChip<F> as sphinx_core::air::WithEvents<'_>>::InputEvents {
         &self.cpu_events
     }
 }
@@ -109,13 +109,13 @@ impl<F: PrimeField32> EventLens<CpuChip<F>> for ExecutionRecord<F> {
 impl<F: PrimeField32, const DEGREE: usize> EventLens<FriFoldChip<F, DEGREE>>
     for ExecutionRecord<F>
 {
-    fn events(&self) -> <FriFoldChip<F, DEGREE> as sphinx_core::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <FriFoldChip<F, DEGREE> as sphinx_core::air::WithEvents<'_>>::InputEvents {
         &self.fri_fold_events
     }
 }
 
 impl<F: PrimeField32> EventLens<Poseidon2Chip<F>> for ExecutionRecord<F> {
-    fn events(&self) -> <Poseidon2Chip<F> as sphinx_core::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <Poseidon2Chip<F> as sphinx_core::air::WithEvents<'_>>::InputEvents {
         &self.poseidon2_events
     }
 }
@@ -123,31 +123,31 @@ impl<F: PrimeField32> EventLens<Poseidon2Chip<F>> for ExecutionRecord<F> {
 impl<F: PrimeField32, const DEGREE: usize> EventLens<Poseidon2WideChip<F, DEGREE>>
     for ExecutionRecord<F>
 {
-    fn events(&self) -> <Poseidon2WideChip<F, DEGREE> as sphinx_core::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <Poseidon2WideChip<F, DEGREE> as sphinx_core::air::WithEvents<'_>>::InputEvents {
         &self.poseidon2_events
     }
 }
 
 impl<F: PrimeField32> EventLens<MemoryGlobalChip<F>> for ExecutionRecord<F> {
-    fn events(&self) -> <MemoryGlobalChip<F> as sphinx_core::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <MemoryGlobalChip<F> as sphinx_core::air::WithEvents<'_>>::InputEvents {
         (&self.first_memory_record, &self.last_memory_record)
     }
 }
 
 impl<F: PrimeField32> EventLens<ProgramChip<F>> for ExecutionRecord<F> {
-    fn events(&self) -> <ProgramChip<F> as sphinx_core::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <ProgramChip<F> as sphinx_core::air::WithEvents<'_>>::InputEvents {
         (&self.program.instructions, &self.cpu_events)
     }
 }
 
 impl<F: PrimeField32> EventLens<RangeCheckChip<F>> for ExecutionRecord<F> {
-    fn events(&self) -> <RangeCheckChip<F> as sphinx_core::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <RangeCheckChip<F> as sphinx_core::air::WithEvents<'_>>::InputEvents {
         &self.range_check_events
     }
 }
 
 impl<F: PrimeField32, const DEGREE: usize> EventLens<MultiChip<F, DEGREE>> for ExecutionRecord<F> {
-    fn events(&self) -> <MultiChip<F, DEGREE> as sphinx_core::air::WithEvents<'_>>::Events {
+    fn events(&self) -> <MultiChip<F, DEGREE> as sphinx_core::air::WithEvents<'_>>::InputEvents {
         (
             <Self as EventLens<FriFoldChip<F, DEGREE>>>::events(self),
             <Self as EventLens<Poseidon2Chip<F>>>::events(self),


### PR DESCRIPTION
Previously: https://github.com/lurk-lab/sphinx/pull/9

This applies the same logic to output events in `generate_trace`.

### General approach
```rust
// implemented on the chip
trait WithEvents<'a> {
  type InputEvents : 'a;
  type OutputEvents: 'a;
}

// implemented on the record
trait EventLens<T: for <'a> WithEvent<'a>> {
  fn events<'a>(&'a self) -> <T as WithEvents<'a>>::InputEvents;
}
// implemented on the record
trait EventMutLens<T: for <'a> WithEvent<'a>> {
  fn events<'a>(&'a mut self, events: <T as WithEvents<'a>>::OutputEvents);
}
```

Now, one would wish that this would be a bit more ergonomic in Rust, because we do have anonymous cartesian products of arbitrary arity (tuples), but we do not have anonymous coproducts - either crate notwithstanding.

## DivRemChip Example

```rust
pub enum DivRemEvent<'a> {
    ByteLookupEvent(&'a ByteLookupEvent),
    MulEvent(&'a AluEvent),
    LtEvent(&'a AluEvent),
}

impl<'a> WithEvents<'a> for DivRemChip {
    type InputEvents = &'a [AluEvent];
    type OutputEvents =  [DivRemEvent<'a>];
}

impl EventMutLens<DivRemChip> for ExecutionRecord {
    fn add_events(&mut self, events: <DivRemChip as crate::air::WithEvents<'_>>::OutputEvents) {
        for event in events {
            match event {
                DivRemEvent::ByteLookupEvent(e) => self.add_byte_lookup_event(*e),
                DivRemEvent::MulEvent(e) => self.add_mul_event(*e),
                DivRemEvent::LtEvent(e) => self.add_lt_event(*e),
            }
        }
    }
}
```