### PR TITLE
chore: allow RUSTSEC-2024-0344 (in actuality, test CI)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ notice = "warn"
 # output a note when they are encountered.
 ignore = [
     #"RUSTSEC-0000-0000",
+    "RUSTSEC-2024-0344", # we don't care about constant-timeness in a zkp
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
This is made obsolete by #56 I'm just testing CI