### PR TITLE
chore: E2E test for checking if Plonk parameters require regenerating

### DIFF
--- a/prover/src/install.rs
+++ b/prover/src/install.rs
@@ -12,7 +12,7 @@ use reqwest::Client;
 use crate::utils::block_on;
 
 /// The base URL for the S3 bucket containing the plonk bn254 artifacts.
-pub const PLONK_BN254_ARTIFACTS_URL_BASE: &str = "s3://sphinx-plonk-params";
+pub const PLONK_BN254_ARTIFACTS_URL_BASE: &str = "https://sphinx-plonk-params.s3.amazonaws.com";
 
 /// The current version of the plonk bn254 artifacts.
 pub const PLONK_BN254_ARTIFACTS_COMMIT: &str = "4a525e9f";

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -781,7 +781,7 @@ mod tests {
         let artifacts_dir = if build_artifacts {
             try_build_plonk_bn254_artifacts_dev(&prover.wrap_vk, &wrapped_bn254_proof.proof)
         } else {
-            try_install_plonk_bn254_artifacts(true)
+            try_install_plonk_bn254_artifacts(false)
         };
 
         let plonk_bn254_proof = prover.wrap_plonk_bn254(wrapped_bn254_proof, &artifacts_dir);

--- a/sdk/src/artifacts.rs
+++ b/sdk/src/artifacts.rs
@@ -17,7 +17,7 @@ pub fn export_solidity_plonk_bn254_verifier(output_dir: impl Into<PathBuf>) -> R
     let artifacts_dir = if sphinx_prover::build::sphinx_dev_mode() {
         sphinx_prover::build::plonk_bn254_artifacts_dev_dir()
     } else {
-        try_install_plonk_bn254_artifacts(true)
+        try_install_plonk_bn254_artifacts(false)
     };
     let verifier_path = artifacts_dir.join("SphinxVerifier.sol");
 

--- a/sdk/src/provers/local.rs
+++ b/sdk/src/provers/local.rs
@@ -82,7 +82,7 @@ impl Prover for LocalProver {
                         &outer_proof.proof,
                     )
                 } else {
-                    sphinx_prover::build::try_install_plonk_bn254_artifacts(true)
+                    sphinx_prover::build::try_install_plonk_bn254_artifacts(false)
                 };
                 let proof = self.prover.wrap_plonk_bn254(outer_proof, &plonk_bn254_aritfacts);
                 Ok(SphinxProofWithPublicValues {

--- a/sdk/src/provers/mod.rs
+++ b/sdk/src/provers/mod.rs
@@ -80,7 +80,7 @@ pub trait Prover: Send + Sync {
         let plonk_bn254_aritfacts = if sphinx_prover::build::sphinx_dev_mode() {
             sphinx_prover::build::plonk_bn254_artifacts_dev_dir()
         } else {
-            sphinx_prover::build::try_install_plonk_bn254_artifacts(true)
+            sphinx_prover::build::try_install_plonk_bn254_artifacts(false)
         };
         sphinx_prover.verify_plonk_bn254(
             &proof.proof,


### PR DESCRIPTION
I found it useful running this newly introduced test (`test_e2e_check_parameters`) to check if installed Plonk parameters work with current version of sphinx (when particular PR that potentially modifies the Plonk circuit has been merged).

As a side note, this PR includes reverting https access to AWS bucket, as now it is publicly accessed for reading