### PR TITLE
fix: CI: first version grep on bump

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -81,7 +81,7 @@ jobs:
 
           bump_version() {
             cd "$1"
-            OLD_VERSION=$(grep -oP 'version = "\K[^"]+' Cargo.toml)
+            OLD_VERSION=$(grep -oP 'version = "\K[^"]+' Cargo.toml | head -n1)
             if [[ "${{ env.VERSION }}" > "$OLD_VERSION" ]]; then
               sed -i "s/version = \"$OLD_VERSION\"/version = \"${{ env.VERSION }}\"/" Cargo.toml
             else


### PR DESCRIPTION
Noticed and fixed in https://github.com/lurk-lab/zk-light-clients/pull/53

If a Cargo.toml has multiple `version = "..."` lines due to dependencies in the format `dep = { version = "blah" }`, this will return multiple results and break the workflow. This change fixes it to only care about the first reported version