### PR TITLE
fix: `debug_constraints` now works with sharding

### DIFF
--- a/core/src/stark/machine.rs
+++ b/core/src/stark/machine.rs
@@ -355,12 +355,8 @@ impl<SC: StarkGenericConfig, A: MachineAir<Val<SC>>> StarkMachine<SC, A> {
     }
 
     #[instrument("debug constraints", level = "debug", skip_all)]
-    pub fn debug_constraints(
-        &self,
-        pk: &StarkProvingKey<SC>,
-        record: A::Record,
-        challenger: &mut SC::Challenger,
-    ) where
+    pub fn debug_constraints(&self, pk: &StarkProvingKey<SC>, record: A::Record)
+    where
         SC::Val: PrimeField32,
         A: for<'a> Air<DebugConstraintBuilder<'a, Val<SC>, SC::Challenge>>,
     {
@@ -371,6 +367,7 @@ impl<SC: StarkGenericConfig, A: MachineAir<Val<SC>>> StarkMachine<SC, A> {
 
         let mut cumulative_sum = SC::Challenge::zero();
         for shard in shards.iter() {
+            let mut challenger = self.config().challenger();
             // Filter the chips based on what is used.
             let chips = self.shard_chips(shard).collect::<Vec<_>>();
 

--- a/core/src/utils/prove.rs
+++ b/core/src/utils/prove.rs
@@ -121,8 +121,7 @@ where
         // If debugging is enabled, we will also debug the constraints.
         #[cfg(feature = "debug")]
         {
-            let mut challenger = machine.config().challenger();
-            machine.debug_constraints(&pk, runtime.record.clone(), &mut challenger);
+            machine.debug_constraints(&pk, runtime.record.clone());
         }
 
         // Generate the proof and return the proof and public values.
@@ -318,9 +317,8 @@ where
 {
     #[cfg(feature = "debug")]
     {
-        let mut challenger_clone = machine.config().challenger();
         let record_clone = record.clone();
-        machine.debug_constraints(pk, record_clone, &mut challenger_clone);
+        machine.debug_constraints(pk, record_clone);
     }
     let stats = record.stats().clone();
     let cycles = stats.get("cpu_events").unwrap();


### PR DESCRIPTION
The `debug_constraints` code is slightly different from the `machine.verify` function.

In `verify`, each shard gets its own fresh copy of the `challenger` passed to it's `verify_shard` function:
https://github.com/lurk-lab/sphinx/blob/36e8009c41ce276d79fb2ccb7b4b8cedfa1c50cc/core/src/stark/machine.rs#L334

In `debug_constraints`,  the same challenger is reused for all shards, without cloning:
https://github.com/lurk-lab/sphinx/blob/36e8009c41ce276d79fb2ccb7b4b8cedfa1c50cc/core/src/stark/machine.rs#L399

This means that `debug_constraints` can fail with "non-zero cumulative sum" even if that is not actually the case, if there are multiple shards in the proof. It happens because the same random challenge should be used for all shards (they all share the same lookup argument), but in `debug_constraints` each shard would get a different challenge.

This PR has a very small change to remove the `challenger` parameter from `debug_constraints` and always build a new fresh challenger using `self.config().challenger()` for each shard.

Removing the parameter will break `loam` compilation (we call `debug_constraints` in some tests there), but a companion PR will be opened shortly.