### PR TITLE
ci: Fix `check-downstream-compiles`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,15 +185,6 @@ jobs:
         with:
           pull_token: ${{ secrets.REPO_TOKEN }}
           perf: false
-      - name: Install deps
-        run: |
-          if [[ "${{ matrix.downstream-path }}" == "aptos" || "${{ matrix.downstream-path }}" == "ethereum" ]]; then
-            sudo apt-get update && sudo apt-get install -y build-essential pkg-config libssl-dev libudev-dev cmake
-            cd sphinx/cli
-            cargo install --locked --force --path .
-            cargo prove install-toolchain
-            echo "RUSTFLAGS=${{env.RUSTFLAGS}} --cfg tokio_unstable" | tee -a $GITHUB_ENV
-          fi
       - uses: actions/checkout@v4
         with:
           repository: argumentcomputer/${{ matrix.repo }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,4 +203,3 @@ jobs:
         with:
           upstream-path: "sphinx"
           downstream-path: "${{ matrix.repo }}/${{ matrix.path }}"
-          patch-ssh: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,7 +176,6 @@ jobs:
         with:
           repository: argumentcomputer/ci-workflows
           path: ci-workflows
-          ref: fix-workspace
       - uses: ./ci-workflows/.github/actions/ci-env
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,6 +176,7 @@ jobs:
         with:
           repository: argumentcomputer/ci-workflows
           path: ci-workflows
+          ref: fix-workspace
       - uses: ./ci-workflows/.github/actions/ci-env
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Switches to the Rust crate action in https://github.com/argumentcomputer/ci-workflows/pull/71

To be merged after the above