### PR TITLE
refactor: Improve cargo prove build reproducibility

### DIFF
--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -114,10 +114,13 @@ pub(crate) fn build_program(args: &BuildArgs) -> Result<Utf8PathBuf> {
         if args.ignore_rust_version {
             cargo_args.push("--ignore-rust-version");
         }
+        cargo_args.push("-Ztrim-paths");
 
         let result = Command::new("cargo")
             .env("RUSTUP_TOOLCHAIN", "succinct")
             .env("CARGO_ENCODED_RUSTFLAGS", rust_flags.join("\x1f"))
+            // TODO: remove once trim-paths is supported - https://github.com/rust-lang/rust/issues/111540
+            .env("RUSTC_BOOTSTRAP", "1") // allows trim-paths.
             .args(&cargo_args)
             .status()
             .context("Failed to run cargo command.")?;


### PR DESCRIPTION
- Added a '-Ztrim-paths' argument to the 'cargo_args' vector.
- Added a provisional solution to enable 'trim-paths', linking the associated Rust issue for context.

Fixes https://github.com/argumentcomputer/zk-light-clients/issues/40

Before:
```
huitseeker@binky➜examples/lcs/program(remap-paths✗)» strings elf/riscv32im-succinc
t-zkvm-elf|grep io
deserialization failed
a formatting trait implementation returned an error
vec is too large) when slicing `assertion `left range end index PermissionDenied right` failed: AddrNotAvailable0123456789abcdef`
/Users/huitseeker/tmp/sphinx/zkvm/precompiles/src/io.rs
/Users/huitseeker/tmp/sphinx/zkvm/entrypoint/src/syscalls/io.rs
assertion failed: SYSTEM_START >= heap_pos/Users/huitseeker/tmp/sphinx/zkvm/entryp
oint/src/syscalls/memory.rs
```

After:
```
huitseeker@binky➜examples/lcs/program(remap-paths✗)» strings elf/riscv32im-succinct-zkvm-elf|grep io
deserialization failed
a formatting trait implementation returned an error
vec is too large) when slicing `assertion `left range end index PermissionDenied right` failed: AddrNotAvailable0123456789abcdef`
sphinx-precompiles-1.0.0/src/io.rs
sphinx-zkvm-1.0.0/src/syscalls/io.rs
assertion failed: SYSTEM_START >= heap_possphinx-zkvm-1.0.0/src/syscalls/memory.rs
```

QoL: this should reduce our own diff count through path normalization.