### PR TITLE
fix: Remove bls12_381 dependency from sphinx-precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4475,7 +4475,6 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "bincode",
- "bls12_381 0.8.0",
  "cfg-if",
  "getrandom",
  "hybrid-array",

--- a/zkvm/precompiles/Cargo.toml
+++ b/zkvm/precompiles/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }
-bls12_381 = { workspace = true }
 cfg-if = { workspace = true }
 getrandom = { workspace = true, features = ["custom"] }
 hybrid-array = { workspace = true }


### PR DESCRIPTION
Hopefully this makes dependency cycles a non-issue so bls12_381 can depend on sphinx crates.