### PR TITLE
fix: Fix `shard_batch_size = 0` support and re-add the cycle count print for execution

### DIFF
--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -1037,6 +1037,10 @@ impl<'a> Runtime<'a> {
         self.emit_events = false;
         self.print_report = true;
         while !self.execute()? {}
+
+        // Print the summary.
+        tracing::info!("summary: cycles={}", self.state.global_clk,);
+
         Ok(())
     }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -423,7 +423,12 @@ impl SphinxProver {
         );
 
         let mut reduce_proofs = Vec::new();
-        let shard_batch_size = opts.recursion_opts.shard_batch_size;
+        // We want the ability to set SHARD_BATCH_SIZE to 0 to run everything in one chunk
+        let shard_batch_size = if opts.recursion_opts.shard_batch_size > 0 {
+            opts.recursion_opts.shard_batch_size
+        } else {
+            usize::MAX
+        };
         for inputs in core_inputs.chunks(shard_batch_size) {
             let proofs = inputs
                 .into_par_iter()


### PR DESCRIPTION
Fixes #160 

Reintroduces a cycle count for execution-only runs so we can fix the LC repo's cycle-count-regression CI check. The print is added only to `run_untraced`, which is called by `client.execute(...).run()`.

Example output:
```
2024-08-26T17:31:55.638116Z  INFO execute: clk = 0 pc = 0x200d04
2024-08-26T17:31:55.638896Z  INFO execute: summary: cycles=7157
2024-08-26T17:31:55.638945Z  INFO execute: close time.busy=1.45ms time.idle=2.30µs
```