### PR TITLE
fix: Update sphinx circuit version

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -30,4 +30,4 @@ use stark::StarkGenericConfig;
 /// This string should be updated whenever any step in verifying an SP1 proof changes, including
 /// core, recursion, and plonk-bn254. This string is used to download SP1 artifacts and the gnark
 /// docker image.
-pub const SPHINX_CIRCUIT_VERSION: &str = "v1.0.8-testnet";
+pub const SPHINX_CIRCUIT_VERSION: &str = "v1.0.8.1-testnet";


### PR DESCRIPTION
After merging #176, the old parameters were invalidated.