### PR TITLE
ci: Regenerate Plonk artifacts on `push: dev`

### DIFF
--- a/.github/workflows/plonk-artifacts.yml
+++ b/.github/workflows/plonk-artifacts.yml
@@ -1,0 +1,31 @@
+name: Regenerate Plonk artifacts
+
+on:
+  push:
+    branches: dev
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: CI Test Suite
+    runs-on: warp-ubuntu-latest-x64-32x
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: argumentcomputer/ci-workflows
+      - uses: ./.github/actions/ci-env
+      - uses: actions/checkout@v4
+      - name: Setup CI
+        uses: ./.github/actions/setup
+        with:
+          pull_token: ${{ secrets.REPO_TOKEN }}
+      - name: Generate Plonk artifacts
+        run: |
+          RUST_LOG=debug make build-plonk-bn254
+          #echo "version" | make release-plonk-bn254
+          echo "Finished building parameters"
+        working-directory: ${{ github.workspace }}/prover

--- a/.github/workflows/plonk-artifacts.yml
+++ b/.github/workflows/plonk-artifacts.yml
@@ -1,6 +1,6 @@
-# Generates and uploads new Plonk artifacts to S3 when  and manual release
-# On `push`, the version/file name is the commit hash
-# Use `workflow_dispatch` for Sphinx releases, with manually specified version name
+# Generates and uploads new Plonk artifacts to S3, named `SPHINX_CIRCUIT_VERSION.tar.gz` unless manually overriden
+# On `push`, uploads new parameters only if there's no matching `SPHINX_CIRCUIT_VERSION.tar.gz` in S3
+# On `workflow_dispatch`, force-uploads new parameters regardless of existing files in S3
 name: Update Plonk artifacts in S3
 
 on:
@@ -9,9 +9,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Artifact version used for archive name, e.g. v1.0.0-testnet"
+        description: "Artifact version used for archive name, e.g. `v1.0.0-testnet`. Defaults to `SPHINX_CIRCUIT_VERSION` in `core/src/lib.rs`"
         type: string
-        required: true
+        required: false
+        # Set to `SPHINX_CIRCUIT_VERSION` in subsequent step
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -35,33 +37,49 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y awscli
+          echo "AWS_REGION=us-east-2" | tee -a $GITHUB_ENV
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.S3_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.S3_SECRET_KEY }}
-          aws-region: us-east-2
+          aws-region: ${{ env.AWS_REGION }}
       - name: Check for existing artifacts
         id: check-s3
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            VERSION=$(grep -r "const SPHINX_CIRCUIT_VERSION" core/src/lib.rs | awk -F '"' '{print $2}')
-          else
-            VERSION=${{ inputs.version }}
+          BUCKET_NAME="sphinx-plonk-params"
+          VERSION=$(grep -r "const SPHINX_CIRCUIT_VERSION" core/src/lib.rs | awk -F '"' '{print $2}')
+
+          # Capture both output and error without exiting
+          BUCKET_CHECK=$(aws s3 ls "s3://$BUCKET_NAME" 2>&1 || true)
+
+          # Create the bucket if it doesn't exist
+          if [[ "$BUCKET_CHECK" == *"NoSuchBucket"* ]]; then
+            echo "Bucket $BUCKET_NAME does not exist, creating..."
+            aws s3 mb s3://$BUCKET_NAME --region ${{ env.AWS_REGION }}
           fi
 
-          BUCKET_NAME="sphinx-plonk-params"
+          # On push, only create new parameters if `SPHINX_CIRCUIT_VERSION.tar.gz` doesn't exist in S3
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            FILE=$(aws s3 ls "s3://${BUCKET_NAME}/${VERSION}.tar.gz")
 
-          FILE=$(aws s3 ls "s3://${BUCKET_NAME}/${VERSION}.tar.gz")
-
-          if [[ -n "$FILE" ]]; then
-            echo "File ${VERSION}.tar.gz exists in $BUCKET_NAME"
-            echo "needs-update=false" | tee -a $GITHUB_OUTPUT
+            if [[ -n "$FILE" ]]; then
+              echo "File ${VERSION}.tar.gz already exists in $BUCKET_NAME, exiting..."
+              NEEDS_UPDATE=false
+            else
+              NEEDS_UPDATE=true
+            fi
+          # On `workflow_dispatch`, always create new parameters.
+          # Default to `SPHINX_CIRCUIT_VERSION` if no input was provided
           else
-            echo "needs-update=true" | tee -a $GITHUB_OUTPUT
+            if [[ -n "${{ inputs.version }}" ]]; then
+              VERSION=${{ inputs.version }}
+            fi
+            NEEDS_UPDATE=true
           fi
 
           echo "VERSION=$VERSION" | tee -a $GITHUB_ENV
+          echo "needs-update=NEEDS_UPDATE" | tee -a $GITHUB_OUTPUT
       - name: Generate Plonk artifacts
         if: ${{ steps.check-s3.outputs.needs-update == "true" }}
         run: |

--- a/.github/workflows/plonk-artifacts.yml
+++ b/.github/workflows/plonk-artifacts.yml
@@ -23,9 +23,23 @@ jobs:
         uses: ./.github/actions/setup
         with:
           pull_token: ${{ secrets.REPO_TOKEN }}
-      - name: Generate Plonk artifacts
+      - name: Install AWS CLI
         run: |
-          RUST_LOG=debug make build-plonk-bn254
-          #echo "version" | make release-plonk-bn254
-          echo "Finished building parameters"
-        working-directory: ${{ github.workspace }}/prover
+          sudo apt-get update
+          sudo apt-get install -y awscli
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.S3_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.S3_SECRET_KEY }}
+          aws-region: us-east-2
+      - name: Test push to S3
+        run: |
+          echo "Test file" > test-file2.txt
+          aws s3 cp "test-file2.txt" "s3://sphinx-plonk-params/test-file2.txt"
+      #- name: Generate Plonk artifacts
+      #  run: |
+      #    RUST_LOG=debug make build-plonk-bn254
+      #    #echo "version" | make release-plonk-bn254
+      #    echo "Finished building parameters"
+      #  working-directory: ${{ github.workspace }}/prover

--- a/.github/workflows/plonk-artifacts.yml
+++ b/.github/workflows/plonk-artifacts.yml
@@ -1,17 +1,25 @@
-name: Regenerate Plonk artifacts
+# Generates and uploads new Plonk artifacts to S3 on every push to `dev` and manual release
+# On `push`, the version/file name is the commit hash
+# Use `workflow_dispatch` for Sphinx releases, with manually specified version name
+name: Update Plonk artifacts in S3
 
 on:
   push:
     branches: dev
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Artifact version used for archive name, e.g. v1.0.0-testnet"
+        type: string
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: CI Test Suite
+  update-plonk-artifacts:
+    name: Update Plonk artifacts
     runs-on: warp-ubuntu-latest-x64-32x
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +31,14 @@ jobs:
         uses: ./.github/actions/setup
         with:
           pull_token: ${{ secrets.REPO_TOKEN }}
+      - name: Parse inputs
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            VERSION=$(git rev-parse --short HEAD)
+          else
+            VERSION=${{ inputs.version }}
+          fi
+          echo "VERSION=$VERSION" | tee -a $GITHUB_ENV
       - name: Install AWS CLI
         run: |
           sudo apt-get update
@@ -33,13 +49,11 @@ jobs:
           aws-access-key-id: ${{ secrets.S3_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.S3_SECRET_KEY }}
           aws-region: us-east-2
-      - name: Test push to S3
+      - name: Generate Plonk artifacts
         run: |
-          echo "Test file" > test-file2.txt
-          aws s3 cp "test-file2.txt" "s3://sphinx-plonk-params/test-file2.txt"
-      #- name: Generate Plonk artifacts
-      #  run: |
-      #    RUST_LOG=debug make build-plonk-bn254
-      #    #echo "version" | make release-plonk-bn254
-      #    echo "Finished building parameters"
-      #  working-directory: ${{ github.workspace }}/prover
+          make build-plonk-bn254
+        working-directory: ${{ github.workspace }}/prover
+      - name: Release tarball on S3
+        run: |
+          echo "${{ env.VERSION }}" | make release-plonk-bn254
+        working-directory: ${{ github.workspace }}/prover

--- a/.github/workflows/plonk-artifacts.yml
+++ b/.github/workflows/plonk-artifacts.yml
@@ -1,4 +1,4 @@
-# Generates and uploads new Plonk artifacts to S3 on every push to `dev` and manual release
+# Generates and uploads new Plonk artifacts to S3 when  and manual release
 # On `push`, the version/file name is the commit hash
 # Use `workflow_dispatch` for Sphinx releases, with manually specified version name
 name: Update Plonk artifacts in S3
@@ -31,14 +31,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           pull_token: ${{ secrets.REPO_TOKEN }}
-      - name: Parse inputs
-        run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            VERSION=$(git rev-parse --short HEAD)
-          else
-            VERSION=${{ inputs.version }}
-          fi
-          echo "VERSION=$VERSION" | tee -a $GITHUB_ENV
       - name: Install AWS CLI
         run: |
           sudo apt-get update
@@ -49,11 +41,34 @@ jobs:
           aws-access-key-id: ${{ secrets.S3_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.S3_SECRET_KEY }}
           aws-region: us-east-2
+      - name: Check for existing artifacts
+        id: check-s3
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            VERSION=$(grep -r "const SPHINX_CIRCUIT_VERSION" core/src/lib.rs | awk -F '"' '{print $2}')
+          else
+            VERSION=${{ inputs.version }}
+          fi
+
+          BUCKET_NAME="sphinx-plonk-params"
+
+          FILE=$(aws s3 ls "s3://${BUCKET_NAME}/${VERSION}.tar.gz")
+
+          if [[ -n "$FILE" ]]; then
+            echo "File ${VERSION}.tar.gz exists in $BUCKET_NAME"
+            echo "needs-update=false" | tee -a $GITHUB_OUTPUT
+          else
+            echo "needs-update=true" | tee -a $GITHUB_OUTPUT
+          fi
+
+          echo "VERSION=$VERSION" | tee -a $GITHUB_ENV
       - name: Generate Plonk artifacts
+        if: ${{ steps.check-s3.outputs.needs-update == "true" }}
         run: |
           make build-plonk-bn254
         working-directory: ${{ github.workspace }}/prover
       - name: Release tarball on S3
+        if: ${{ steps.check-s3.outputs.needs-update == "true" }}
         run: |
           echo "${{ env.VERSION }}" | make release-plonk-bn254
         working-directory: ${{ github.workspace }}/prover

--- a/prover/release.sh
+++ b/prover/release.sh
@@ -21,10 +21,10 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Put the version in the build directory
+# Put the commit hash and version in the build directory
 echo "$COMMIT_HASH $VERSION" > ./build/SPHINX_COMMIT
 
-# Create archive named after the commit hash
+# Create archive named after the version
 ARCHIVE_NAME="${VERSION}.tar.gz"
 cd $FILE_TO_UPLOAD
 tar --exclude='srs.bin' --exclude='srs_lagrange.bin' -czvf "../$ARCHIVE_NAME" .
@@ -34,7 +34,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Upload the file to S3, naming it after the current commit hash
+# Upload the file to S3, naming it after the current version
 aws s3 cp "$ARCHIVE_NAME" "s3://$S3_BUCKET/$ARCHIVE_NAME"
 if [ $? -ne 0 ]; then
     echo "Failed to upload file to S3."


### PR DESCRIPTION
- Regenerates new Plonk artifacts and uploads to S3 on every push to `dev`, if a file named `<SPHINX_CIRCUIT_VERSION>.tar.gz` doesn't exist in S3
- Adds a manual `workflow_dispatch` option to release new artifacts with a custom name, e.g. `v1.0.0-testnet.tar.gz`, defaulting to `SPHINX_CIRCUIT_VERSION` in https://github.com/argumentcomputer/sphinx/blob/dev/core/src/lib.rs#L33. This option force-pushes the new parameters regardless of whether a matching file name already exists in the bucket.

In either case, the `sphinx-plonk-params` S3 bucket is created if not found.

### Succesful runs
- [Generate artifacts](https://github.com/argumentcomputer/sphinx/actions/runs/11388703859/job/31686294065)
- [Push test file to S3](https://github.com/argumentcomputer/sphinx/actions/runs/11390464234/job/31692147099)

> [!NOTE]
> Artifact generation takes up to 30 minutes on a 32 vCPU Warpbuild runner. If performance is a concern, this could be reduced by 10-15 minutes with a more expensive AWS runner.