### PR TITLE
ci: Check `SPHINX_CIRCUIT_VERSION` on `pull_request`

### DIFF
--- a/.github/workflows/plonk-artifacts.yml
+++ b/.github/workflows/plonk-artifacts.yml
@@ -81,12 +81,12 @@ jobs:
           echo "VERSION=$VERSION" | tee -a $GITHUB_ENV
           echo "needs-update=NEEDS_UPDATE" | tee -a $GITHUB_OUTPUT
       - name: Generate Plonk artifacts
-        if: ${{ steps.check-s3.outputs.needs-update == "true" }}
+        if: ${{ steps.check-s3.outputs.needs-update == 'true' }}
         run: |
           make build-plonk-bn254
         working-directory: ${{ github.workspace }}/prover
       - name: Release tarball on S3
-        if: ${{ steps.check-s3.outputs.needs-update == "true" }}
+        if: ${{ steps.check-s3.outputs.needs-update == 'true' }}
         run: |
           echo "${{ env.VERSION }}" | make release-plonk-bn254
         working-directory: ${{ github.workspace }}/prover

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,11 @@ jobs:
         uses: ./.github/actions/setup
         with:
           pull_token: ${{ secrets.REPO_TOKEN }}
+      # Prints the value of `SPHINX_CIRCUIT_VERSION`, erroring if `grep` can't find the constant
+      - name: Check circuit version
+        run: |
+          SPHINX_VERSION=$(grep -r "const SPHINX_CIRCUIT_VERSION" core/src/lib.rs | awk -F '"' '{print $2}')
+          echo "Sphinx circuit version = $SPHINX_VERSION"
       - name: Check Rustfmt Code Style
         run: cargo fmt --all --check
       - name: check *everything* compiles


### PR DESCRIPTION
- Checks for `SPHINX_CIRCUIT_VERSION` on PR to make sure the constant hasn't moved per https://github.com/argumentcomputer/sphinx/pull/189#discussion_r1811357510. The check runs during the `clippy` job but before the more time-consuming steps so it will fail fast.
- Fixes a typo in the artifact regen workflow