### PR TITLE
feat: Implement custom logging initialization for SP1 package

### DIFF
--- a/recursion/gnark-ffi/go/sp1/logging.go
+++ b/recursion/gnark-ffi/go/sp1/logging.go
@@ -14,7 +14,7 @@ func init() {
 
 	// Configure the global log level based on the environment variable
 	switch logLevel {
-	case "disabled", "false", "none":
+	case "disabled", "false", "none", "off":
 		zerolog.SetGlobalLevel(zerolog.Disabled)
 	case "panic":
 		zerolog.SetGlobalLevel(zerolog.PanicLevel)

--- a/recursion/gnark-ffi/go/sp1/logging.go
+++ b/recursion/gnark-ffi/go/sp1/logging.go
@@ -1,0 +1,37 @@
+package sp1
+
+import (
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func init() {
+	// Get log level from environment variable
+	logLevel := strings.ToLower(os.Getenv("SP1_GO_LOG"))
+
+	// Configure the global log level based on the environment variable
+	switch logLevel {
+	case "disabled", "false", "none":
+		zerolog.SetGlobalLevel(zerolog.Disabled)
+	case "panic":
+		zerolog.SetGlobalLevel(zerolog.PanicLevel)
+	case "fatal":
+		zerolog.SetGlobalLevel(zerolog.FatalLevel)
+	case "error":
+		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	case "warn", "warning":
+		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	case "debug":
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	case "trace":
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	default: // Including "info" and empty string
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	}
+
+	// Configure zerolog to use a console writer
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+}


### PR DESCRIPTION
Configures logging for go through an environment variable.

Example usage:
```
SP1_GO_LOG=false cargo test

./cargo test
SP1_GO_LOG=debug ./cargo test
```

This solution works because:

- The `init()` function in logging.go will run before any other code in the package
- Since `gnark` uses `zerolog`, setting the global log level will affect all logging throughout the application, including in dependencies
- The change is minimal and contained to just one file (as long as the `main.go` module early-loads the sp1 package)
- It doesn't require any changes to the Rust code or to gnark's source code
- It's configurable through an environment variable