### PR TITLE
fix: Don't use `perf` in plonk-artifacts workflow

### DIFF
--- a/.github/workflows/plonk-artifacts.yml
+++ b/.github/workflows/plonk-artifacts.yml
@@ -33,6 +33,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           pull_token: ${{ secrets.REPO_TOKEN }}
+          perf: false
       - name: Install AWS CLI
         run: |
           sudo apt-get update
@@ -80,8 +81,6 @@ jobs:
 
           echo "VERSION=$VERSION" | tee -a $GITHUB_ENV
           echo "needs-update=$NEEDS_UPDATE" | tee -a $GITHUB_OUTPUT
-          # Disable `SP1_DEV` as it breaks artifact generation
-          echo "SP1_DEV=false" | tee -a $GITHUB_ENV
       - name: Generate Plonk artifacts
         if: ${{ steps.check-s3.outputs.needs-update == 'true' }}
         run: |


### PR DESCRIPTION
Since the setup action will set both `SP1_DEV=true` and `FRI_QUERIES=1`, the plonk artifact generation fails. We can override `SP1_DEV` but cannot override `FRI_QUERIES` since different StarkMachines use different values (and they are all overridden by the same `FRI_QUERIES` envvar). Unsetting variables set via `GITHUB_ENV` is not currently supported according to https://github.com/actions/runner/issues/1126

So just pass `perf: false` instead. The `Makefile` uses `--release` and sets `-Ctarget-cpu=native` by itself so we don't need any of the `perf` setup items